### PR TITLE
Simplify html selector

### DIFF
--- a/src/utils/dark.ts
+++ b/src/utils/dark.ts
@@ -19,7 +19,7 @@ export const isDark = computed({
 watch(
   isDark,
   (v) => {
-    const html = document.getElementsByTagName('html')[0]
+    const html = document.documentElement
     html.classList.toggle('schema-dark', v)
   },
   { immediate: true },


### PR DESCRIPTION
Just a minor simplification. I prefer the following over selecting the root element:

```diff
-const html = document.getElementsByTagName('html')[0]
+const html = document.documentElement
```

Thanks for your work on this starter project!