### PR TITLE
SVG favicon with dark mode support 

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <link rel="icon" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Vitesse</title>
 </head>
 <body>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,6 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32"
-  preserveAspectRatio="xMidYMid meet" viewBox="0 0 32 32">
-  <path
-    d="M27.562 26L17.17 8.928l2.366-3.888L17.828 4L16 7.005L14.17 4l-1.708 1.04l2.366 3.888L4.438 26H2v2h28v-2zM16 10.85L25.22 26H17v-8h-2v8H6.78z"
-    fill="#fff" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <style>
+    path { fill: #000000; }
+    @media (prefers-color-scheme: dark) {
+      path { fill: #ffffff; }
+    }
+  </style>
+  <path d="M27.562 26L17.17 8.928l2.366-3.888L17.828 4L16 7.005L14.17 4l-1.708 1.04l2.366 3.888L4.438 26H2v2h28v-2zM16 10.85L25.22 26H17v-8h-2v8H6.78z" />
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <style>
-    path { fill: #000000; }
+    path { fill: #222; }
     @media (prefers-color-scheme: dark) {
       path { fill: #ffffff; }
     }


### PR DESCRIPTION
## Describe the PR

This pull request adds dark mode support to the SVG favicon. Its path stays the same. Vector favicons are:
- future-proof
- resolution-agnostic – they look crisp regardless of how large the displays is
- quite small

Since CSS media queries are available inside the SVG files, `prefers-color-scheme` helps to provide support for dark mode.

## Related issues

No related issues found.