### PR TITLE
fix: port option

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "vite -p 3333 --open",
+    "dev": "vite --port 3333 --open",
     "build": "cross-env NODE_ENV=production vite build"
   },
   "dependencies": {


### PR DESCRIPTION
Vite doesn't have -p shorthand for port option.