### PR TITLE
chore: skip netlify automatic npm install

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
+[build.environment]
+  NPM_FLAGS = "--prefix=/dev/null"
+
 [build]
   publish = "dist"
   command = "npx pnpm i --store=node_modules/.pnpm-store && npm run build"


### PR DESCRIPTION
Hi, this will prevent netlify automatic install npm dependencies., can save build time.