### PR TITLE
chore: update i18n-ally vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
     "octref.vetur",
-    "antfu.i18n-ally",
+    "lokalise.i18n-ally",
     "antfu.iconify",
     "dbaeumer.vscode-eslint",
     "bradlc.vscode-tailwindcss"


### PR DESCRIPTION
## Why
`antfu.i18n-ally` got renamed to `lokalise.i18n-ally,` but `.vscode/extensions.json` hasn't been changed to reflect it yet.

This prompts Visual Studio Code to recommend you to install `antfu.i18n-ally` despite being deprecated.
![image](https://user-images.githubusercontent.com/20427094/105469948-3db5ac00-5c99-11eb-845a-7c5a87313d4d.png)

## Proposed changes
- Replace `antfu.i18n-ally` with `lokalise.i18n-ally`.