### PR TITLE
fix: EncodeURIComponent for dynamic name route

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -8,7 +8,7 @@ const name = ref('')
 const router = useRouter()
 const go = () => {
   if (name.value)
-    router.push(`/hi/${name.value}`)
+    router.push(`/hi/${encodeURIComponent(name.value)}`)
 }
 
 const { t } = useI18n()
@@ -36,7 +36,7 @@ const { t } = useI18n()
       :placeholder="t('intro.whats-your-name')"
       type="text"
       autocomplete="false"
-      class="px-4 py-2 border border-gray-200 rounded text-center text-sm outline-none active:outline-none bg-transparent dark:border-gray-700"
+      class="px-4 py-2 text-sm text-center bg-transparent border border-gray-200 rounded outline-none active:outline-none dark:border-gray-700"
       style="width: 250px"
       @keydown.enter="go"
     >
@@ -44,7 +44,7 @@ const { t } = useI18n()
 
     <div>
       <button
-        class="btn m-3 text-sm"
+        class="m-3 text-sm btn"
         :disabled="!name"
         @click="go"
       >


### PR DESCRIPTION
This change fixes a bug in the main page where if you enter your name as a url or something similar it will redirect you to a 404.

This isn't exactly essential as when a user clones this template they will most likely replace all of these files, but for the sake of completeness I thought it might be a good idea to fix this. 

**Current Problem**
index.ts; line 9
```ts 
const go = () => {
  if (name.value)
    router.push(`/hi/${name.value}`)
}
```

If you enter something like `https://github.com/antfu/vitesse` you will be redirected to a 404 page

**Solution**
index.ts; line 9
```ts
const go = () => {
  if (name.value)
    router.push(`/hi/${encodeURIComponent(name.value)}`)
}
```

This will result in `Hi, https://github.com/antfu/vitesse!`

This is just a small bug I ran into during the development of a small project. It is not that important though, so feel free to ignore if you feel like it is not necessary to change :)