### PR TITLE
chore: update shims-vue.d.ts

### DIFF
--- a/src/shims-md.d.ts
+++ b/src/shims-md.d.ts
@@ -1,0 +1,5 @@
+declare module '*.md' {
+  import { ComponentOptions } from 'vue'
+  const Component: ReturnType<typeof defineComponent>
+  export default Component
+}

--- a/src/shims-md.d.ts
+++ b/src/shims-md.d.ts
@@ -1,5 +1,0 @@
-declare module '*.md' {
-  import { ComponentOptions } from 'vue'
-  const Component: ReturnType<typeof defineComponent>
-  export default Component
-}

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -6,6 +6,6 @@ declare module '*.vue' {
 }
 declare module '*.md' {
   import { ComponentOptions } from 'vue'
-  const Component: ReturnType<typeof defineComponent>
-  export default Component
+  const component: ReturnType<ComponentOptions>
+  export default component
 }

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,5 +1,11 @@
+/* eslint-disable import/no-duplicates */
 declare module '*.vue' {
-  import { ComponentOptions } from 'vue'
+  import { ComponentOptions, ComponentOptions } from 'vue'
   const component: ReturnType<ComponentOptions>
   export default component
+}
+declare module '*.md' {
+  import { ComponentOptions } from 'vue'
+  const Component: ReturnType<typeof defineComponent>
+  export default Component
 }

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-duplicates */
 declare module '*.vue' {
-  import { ComponentOptions, ComponentOptions } from 'vue'
+  import { ComponentOptions } from 'vue'
   const component: ReturnType<ComponentOptions>
   export default component
 }

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -3,8 +3,3 @@ declare module '*.vue' {
   const component: ReturnType<ComponentOptions>
   export default component
 }
-
-declare module '*.md' {
-  const Component: ReturnType<typeof defineComponent>
-  export default Component
-}

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,8 +1,7 @@
-import { defineComponent } from 'vue'
-
 declare module '*.vue' {
-  const Component: ReturnType<typeof defineComponent>
-  export default Component
+  import { ComponentOptions } from 'vue'
+  const component: ReturnType<ComponentOptions>
+  export default component
 }
 
 declare module '*.md' {


### PR DESCRIPTION
see https://github.com/vuejs/vue-next-webpack-preview/issues/5#issuecomment-579823346

It has no effect to use, but there's always a `TS` red wavy line which is annoying

and we may lose the ability to  locate the `.vue` file in `.ts`

