### PR TITLE
fix: added extend key to tailwind variants

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,11 +17,13 @@ module.exports = {
     },
   },
   variants: {
-    cursor: ['responsive', 'disabled'],
-    backgroundColor: ['dark', 'hover', 'disabled'],
-    borderColor: ['dark', 'active', 'focus', 'disabled'],
-    textColor: ['dark', 'hover', 'active', 'disabled'],
-    opacity: ['dark', 'hover', 'active', 'focus', 'disabled'],
+    extend: {
+      cursor: ['disabled'],
+      backgroundColor: ['disabled'],
+      borderColor: ['active', 'disabled'],
+      textColor: ['active', 'disabled'],
+      opacity: ['dark', 'active', 'disabled'],
+    }
   },
   darkMode: 'class',
   plugins: [typography],


### PR DESCRIPTION
Hey,

Some variants like focus for background colours was not working for me while I was using Vitesse, it's because the variants key in the tailwind config file does not have extend with it. So things like,

```
<input class="bg-red-600 focus:g-green-600" /> 
```
won't work because the focus variant is not enabled in the config file.

In this PR I have added `extend` key to tailwind variants config and included only the extra variants that are needed for Vitesse. 

