### PR TITLE
fix: horizontal overflow scrollbar when vertical scrollbar appears

### DIFF
--- a/src/styles/main.postcss
+++ b/src/styles/main.postcss
@@ -7,7 +7,6 @@ html,
 body,
 #app {
   height: 100vh;
-  width: 100vw;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
Currently the template has `width: 100vw` on the body, but this causes a horizontal overflow whenever there is a vertical overflow. Removing this doesn't seem to negatively affect anything and prevents a horizontal overflow whenever there is a vertical overflow 