### PR TITLE
feat: enable volar ts plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "volar.tsPlugin": true,
   "i18n-ally.localesPaths": "locales",
   "i18n-ally.keystyle": "nested",
   "i18n-ally.sortKeys": true,

--- a/src/pages/hi/[name].vue
+++ b/src/pages/hi/[name].vue
@@ -6,7 +6,7 @@ import { defineProps } from 'vue'
 const props = defineProps({
   name: {
     type: String,
-    require: true,
+    required: true,
   },
 })
 

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -4,12 +4,6 @@ declare interface Window {
   // extend the window
 }
 
-declare module '*.vue' {
-  import { ComponentOptions } from 'vue'
-  const component: ComponentOptions
-  export default component
-}
-
 // with vite-plugin-md, markdowns can be treat as Vue components
 declare module '*.md' {
   import { ComponentOptions } from 'vue'


### PR DESCRIPTION
volar 0.21.0 supported ts plugin with vscode setting and default disabled.

this pr support enabled ts plugin in user workspace.

note: will broke some users don't use volar.