### PR TITLE
update vite-plugin-vue-i18n, remove unnecessary glob import

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^0.4.3",
     "@iconify/json": "^1.1.310",
-    "@intlify/vite-plugin-vue-i18n": "^1.0.0-beta.17",
+    "@intlify/vite-plugin-vue-i18n": "^2.0.0-rc.2",
     "@types/nprogress": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@vitejs/plugin-vue": "^1.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ dependencies:
 devDependencies:
   '@antfu/eslint-config': 0.4.3_eslint@7.21.0+typescript@4.2.2
   '@iconify/json': 1.1.310
-  '@intlify/vite-plugin-vue-i18n': 1.0.0-beta.17
+  '@intlify/vite-plugin-vue-i18n': 2.0.0-rc.2
   '@types/nprogress': 0.2.0
   '@typescript-eslint/eslint-plugin': 4.15.2_eslint@7.21.0+typescript@4.2.2
   '@vitejs/plugin-vue': 1.1.5_@vue+compiler-sfc@3.0.6
@@ -1161,7 +1161,7 @@ packages:
       node: '>= 10'
     resolution:
       integrity: sha512-0r4v7dnY8g/Jfx2swUWy2GyfH/WvIpWvkU4OIupvxDTWiE8RhcpbOCVvqpVh/xGi0proHQ/r2Dhc0QSItUsfDQ==
-  /@intlify/vite-plugin-vue-i18n/1.0.0-beta.17:
+  /@intlify/vite-plugin-vue-i18n/2.0.0-rc.2:
     dependencies:
       '@intlify/cli': 0.2.0
       '@intlify/shared': 9.0.0
@@ -1171,7 +1171,7 @@ packages:
     engines:
       node: '>= 12'
     resolution:
-      integrity: sha512-Xf68q/uVwfaK17mpvZK4hGJ+zayFCdP6sjJDWp+nUVGxv1Y736vVFxpNzDVR+XYXB1eqwixdr/vo/3yFhsVxBA==
+      integrity: sha512-bH9fhfvYpIoJ8kl7NIU2SzFJOj9MMg37UcRsBNkQGi8U61OhdRt9LhZqCPkNRMhX1QARm2MM7DaftVhlmaHiJA==
   /@knightly/fast-glob/3.2.5-knightly-master.202101180131:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
@@ -5589,7 +5589,7 @@ packages:
 specifiers:
   '@antfu/eslint-config': ^0.4.3
   '@iconify/json': ^1.1.310
-  '@intlify/vite-plugin-vue-i18n': ^1.0.0-beta.17
+  '@intlify/vite-plugin-vue-i18n': ^2.0.0-rc.2
   '@types/nprogress': ^0.2.0
   '@typescript-eslint/eslint-plugin': ^4.15.2
   '@vitejs/plugin-vue': ^1.1.5

--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -1,15 +1,6 @@
 import { createI18n } from 'vue-i18n'
+import messages from '@intlify/vite-plugin-vue-i18n/messages'
 import { UserModule } from '~/types'
-
-// import i18n resources
-// https://vitejs.dev/guide/features.html#glob-import
-const messages = Object.fromEntries(
-  Object.entries(
-    import.meta.globEager('../../locales/*.json'))
-    .map(([key, value]) => {
-      return [key.slice(14, -5), value.default]
-    }),
-)
 
 export const install: UserModule = ({ app }) => {
   const i18n = createI18n({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "types": [
+      "@intlify/vite-plugin-vue-i18n/client",
       "vite/client",
       "vite-plugin-pages/client",
       "vite-plugin-vue-layouts/client"


### PR DESCRIPTION
As shown in the vue-i18n plugin [documentation](https://github.com/intlify/vite-plugin-vue-i18n#static-bundle-importing), we can import all the included locales (configured in `vite.config.ts`) with
```ts
import messages from '@intlify/vite-plugin-vue-i18n/messages'
```
instead of manually doing it with glob import.