### PR TITLE
fix: vue file imports throwing IDE errors

### DIFF
--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -10,3 +10,10 @@ declare module '*.md' {
   const component: ComponentOptions
   export default component
 }
+
+// declare vue files as components
+declare module '*.vue' {
+  import { ComponentOptions } from 'vue'
+  const component: ComponentOptions
+  export default component
+}


### PR DESCRIPTION
Fixes `import App from './App.vue'` throwing ts2307: cannot find module (in `/src/main.ts` and others)