### PR TITLE
this change fix an error of deploy on netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 
 [build]
   publish = "dist"
-  command = "npx pnpm i --store=node_modules/.pnpm-store && npx pnpm run build"
+  command = "vite build"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
I am getting this error after deploying a new packages.json

4:56:26 PM: error An unexpected error occurred: "EEXIST: file already exists, mkdir '/opt/build/repo/node_modules/@babel/highlight/node_modules'".

this quick change does the trick