### PR TITLE
fix: layout higher than display

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3,7 +3,7 @@
 html,
 body,
 #app {
-  height: 100vh;
+  height: 100%;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
in some browsers (e.g. ios safari) `100vh` will extend beyond a users viewport because the address bar is considered for the calculation of the value. Changing to 100% fixes that.

see issue #111