### PR TITLE
i18n: improve french translation

### DIFF
--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2,12 +2,12 @@ button:
   about: À propos de
   back: Retour
   go: Essayer
-  home: Maison
+  home: Accueil
   toggle_dark: Basculer en mode sombre
   toggle_langs: Changer de langue
 intro:
-  desc: Example d'application Vite
+  desc: Exemple d'application Vite
   dynamic-route: Démo de route dynamique
   hi: Salut, {name}!
-  whats-your-name: Comment t'appelles-tu?
+  whats-your-name: Comment t'appelles-tu ?
 not-found: Page non trouvée


### PR DESCRIPTION
Hi,

I submit a small pull request here to fix the french translation.

Two of the fixes are just typos, the third (`Maison` -> `Accueil`) could need an explanation so here it is:
"Maison" in french is your "home building" but "Accueil" is usuallty the wordig on french website to indicate that this link redirect to the root page of the app. Since the icon used is actually a tepee maybe you called this link "Maison" on purpose, so let me know if you need me to remove this third change.

Thanks