### PR TITLE
feat(md): add _blank for all links with http/https

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^7.27.0",
     "https-localhost": "^4.6.5",
+    "markdown-it-link-attributes": "^3.0.0",
     "markdown-it-prism": "^2.1.6",
     "pnpm": "^6.6.2",
     "typescript": "^4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ specifiers:
   cross-env: ^7.0.3
   eslint: ^7.27.0
   https-localhost: ^4.6.5
+  markdown-it-link-attributes: ^3.0.0
   markdown-it-prism: ^2.1.6
   nprogress: ^0.2.0
   pnpm: ^6.6.2
@@ -54,6 +55,7 @@ devDependencies:
   cross-env: 7.0.3
   eslint: 7.27.0
   https-localhost: 4.6.5
+  markdown-it-link-attributes: 3.0.0
   markdown-it-prism: 2.1.6
   pnpm: 6.6.2
   typescript: 4.3.2
@@ -4688,6 +4690,10 @@ packages:
   /map-obj/2.0.0:
     resolution: {integrity: sha1-plzSkIepJZi4eRJXpSPgISIqwfk=}
     engines: {node: '>=4'}
+    dev: true
+
+  /markdown-it-link-attributes/3.0.0:
+    resolution: {integrity: sha512-B34ySxVeo6MuEGSPCWyIYryuXINOvngNZL87Mp7YYfKIf6DcD837+lXA8mo6EBbauKsnGz22ZH0zsbOiQRWTNg==}
     dev: true
 
   /markdown-it-prism/2.1.6:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ import WindiCSS from 'vite-plugin-windicss'
 import { VitePWA } from 'vite-plugin-pwa'
 import VueI18n from '@intlify/vite-plugin-vue-i18n'
 import Prism from 'markdown-it-prism'
+import LinkAttributes from 'markdown-it-link-attributes'
 
 export default defineConfig({
   resolve: {
@@ -37,32 +38,13 @@ export default defineConfig({
       markdownItSetup(md) {
         // https://prismjs.com/
         md.use(Prism)
-
-        // https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
-        // add target="_blank" to all links with http/https
-        const defaultRender
-            = md.renderer.rules.link_open
-            || function(tokens: any, idx: any, options: any, env: any, self: any) {
-              return self.renderToken(tokens, idx, options)
-            }
-        md.renderer.rules.link_open = function(
-          tokens: any,
-          idx: string | number,
-          options: any,
-          env: any,
-          self: any,
-        ) {
-          const hrefIndex = tokens[idx].attrIndex('href')
-          const href = tokens[idx].attrs[hrefIndex][1]
-          if (href.startsWith('http://') || href.startsWith('https://')) {
-            const aIndex = tokens[idx].attrIndex('target')
-            if (aIndex < 0)
-              tokens[idx].attrPush(['target', '_blank'])
-            else
-              tokens[idx].attrs[aIndex][1] = '_blank'
-          }
-          return defaultRender(tokens, idx, options, env, self)
-        }
+        md.use(LinkAttributes, {
+          pattern: /^https?:\/\//,
+          attrs: {
+            target: '_blank',
+            rel: 'noopener',
+          },
+        })
       },
     }),
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,32 @@ export default defineConfig({
       markdownItSetup(md) {
         // https://prismjs.com/
         md.use(Prism)
+
+        // https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
+        // add target="_blank" to all links with http/https
+        const defaultRender
+            = md.renderer.rules.link_open
+            || function(tokens: any, idx: any, options: any, env: any, self: any) {
+              return self.renderToken(tokens, idx, options)
+            }
+        md.renderer.rules.link_open = function(
+          tokens: any,
+          idx: string | number,
+          options: any,
+          env: any,
+          self: any,
+        ) {
+          const hrefIndex = tokens[idx].attrIndex('href')
+          const href = tokens[idx].attrs[hrefIndex][1]
+          if (href.startsWith('http://') || href.startsWith('https://')) {
+            const aIndex = tokens[idx].attrIndex('target')
+            if (aIndex < 0)
+              tokens[idx].attrPush(['target', '_blank'])
+            else
+              tokens[idx].attrs[aIndex][1] = '_blank'
+          }
+          return defaultRender(tokens, idx, options, env, self)
+        }
       },
     }),
 


### PR DESCRIPTION
Add `_blank` for all links with `http://` / `https://`.

I think it's useful for writing links in markdown.
