### PR TITLE
Fix Vuex mismatch and add shim for vue

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -11,7 +11,6 @@ declare module 'vue' {
     CarbonLanguage: typeof import('virtual:vite-icons/carbon/language')['default']
     CarbonDicomOverlay: typeof import('virtual:vite-icons/carbon/dicom-overlay')['default']
     CarbonLogoGithub: typeof import('virtual:vite-icons/carbon/logo-github')['default']
-    CarbonPedestrian: typeof import('virtual:vite-icons/carbon/pedestrian')['default']
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prism-theme-vars": "^0.2.2",
     "vue": "^3.1.2",
     "vue-i18n": "^9.1.6",
-    "vue-router": "^4.0.10"
+    "vue-router": "4.0.8"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ specifiers:
   vite-ssg: ^0.11.4
   vue: ^3.1.2
   vue-i18n: ^9.1.6
-  vue-router: ^4.0.10
+  vue-router: 4.0.8
   vue-tsc: ^0.2.0
 
 dependencies:
@@ -41,7 +41,7 @@ dependencies:
   prism-theme-vars: 0.2.2
   vue: 3.1.2
   vue-i18n: 9.1.6_vue@3.1.2
-  vue-router: 4.0.10_vue@3.1.2
+  vue-router: 4.0.8_vue@3.1.2
 
 devDependencies:
   '@antfu/eslint-config': 0.6.6_eslint@7.29.0+typescript@4.3.4
@@ -67,7 +67,7 @@ devDependencies:
   vite-plugin-pwa: 0.8.1_vite@2.3.8
   vite-plugin-vue-layouts: 0.3.1_vite@2.3.8
   vite-plugin-windicss: 1.1.0_vite@2.3.8
-  vite-ssg: 0.11.4_008cd22a2ff0d6dfd44b78bd52fc2395
+  vite-ssg: 0.11.4_c103deb465e7b1371fee25ff5d62fb54
   vue-tsc: 0.2.0_typescript@4.3.4+vue@3.1.2
 
 packages:
@@ -2274,10 +2274,10 @@ packages:
 
   /@vue/devtools-api/6.0.0-beta.12:
     resolution: {integrity: sha512-PtHmAxFmCyCElV7uTWMrXj+fefwn4lCfTtPo9fPw0SK8/7e3UaFl8IL7lnugJmNFfeKQyuTkSoGvTq1uDaRF6Q==}
-
-  /@vue/devtools-api/6.0.0-beta.14:
-    resolution: {integrity: sha512-44fPrrN1cqcs6bFkT0C+yxTM6PZXLbR+ESh1U1j8UD22yO04gXvxH62HApMjLbS3WqJO/iCNC+CYT+evPQh2EQ==}
     dev: false
+
+  /@vue/devtools-api/6.0.0-beta.15:
+    resolution: {integrity: sha512-quBx4Jjpexo6KDiNUGFr/zF/2A4srKM9S9v2uHgMXSU//hjgq1eGzqkIFql8T9gfX5ZaVOUzYBP3jIdIR3PKIA==}
 
   /@vue/reactivity/3.0.11:
     resolution: {integrity: sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==}
@@ -7344,7 +7344,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-ssg/0.11.4_008cd22a2ff0d6dfd44b78bd52fc2395:
+  /vite-ssg/0.11.4_c103deb465e7b1371fee25ff5d62fb54:
     resolution: {integrity: sha512-JVq45h5IRGxYpHu2yjLdWKAUaTISXrWKjPPDHetNVhP8wp/MGZ1gYhns9XOSfYfLbWSMQgDIjbANAS9XzE/X3Q==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -7366,7 +7366,7 @@ packages:
       prettier: 2.3.1
       vite: 2.3.8
       vue: 3.1.2
-      vue-router: 4.0.10_vue@3.1.2
+      vue-router: 4.0.8_vue@3.1.2
       yargs: 17.0.1
     transitivePeerDependencies:
       - bufferutil
@@ -7577,23 +7577,23 @@ packages:
       vue: 3.1.2
     dev: false
 
-  /vue-router/4.0.10_vue@3.1.2:
-    resolution: {integrity: sha512-YbPf6QnZpyyWfnk7CUt2Bme+vo7TLfg1nGZNkvYqKYh4vLaFw6Gn8bPGdmt5m4qrGnKoXLqc4htAsd3dIukICA==}
-    peerDependencies:
-      vue: ^3.0.0
-    dependencies:
-      '@vue/devtools-api': 6.0.0-beta.14
-      vue: 3.1.2
-    dev: false
-
   /vue-router/4.0.8_vue@3.0.11:
     resolution: {integrity: sha512-42mWSQaH7CCBQDspQTHv63f34VEnZC20g9QNK4WJ/zW8SdIUeT6TQ2i/78fjF/pVBUPLBWrGhvB7uDnaz7O/pA==}
     peerDependencies:
       vue: ^3.0.0
     dependencies:
-      '@vue/devtools-api': 6.0.0-beta.12
+      '@vue/devtools-api': 6.0.0-beta.15
       vue: 3.0.11
     dev: true
+
+  /vue-router/4.0.8_vue@3.1.2:
+    resolution: {integrity: sha512-42mWSQaH7CCBQDspQTHv63f34VEnZC20g9QNK4WJ/zW8SdIUeT6TQ2i/78fjF/pVBUPLBWrGhvB7uDnaz7O/pA==}
+    peerDependencies:
+      vue: ^3.0.0
+    dependencies:
+      '@vue/devtools-api': 6.0.0-beta.15
+      vue: 3.1.2
+    dev: false
 
   /vue-template-es2015-compiler/1.9.1:
     resolution: {integrity: sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==}

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -10,3 +10,9 @@ declare module '*.md' {
   const component: ComponentOptions
   export default component
 }
+
+declare module '*.vue' {
+  import { ComponentOptions } from 'vue'
+  const component: ComponentOptions
+  export default component
+}


### PR DESCRIPTION
**Problems**
On cloning the master branch, TypeScript complains about incompatible Vuex versions used by plugins: 

```
Argument of type 'import("/Users/USERNAME/Downloads/vitesse/node_modules/.pnpm/vue-router@4.0.10_vue@3.1.2/node_modules/vue-router/dist/vue-router").RouteRecordRaw[]' is not assignable to parameter of type 'import("/Users/USERNAME/Downloads/vitesse/node_modules/.pnpm/vue-router@4.0.8_vue@3.0.11/node_modules/vue-router/dist/vue-router").RouteRecordRaw[]'.
  Type 'import("/Users/USERNAME/Downloads/vitesse/node_modules/.pnpm/vue-router@4.0.10_vue@3.1.2/node_modules/vue-router/dist/vue-router").RouteRecordRaw' is not assignable to type 'import("/Users/USERNAME/Downloads/vitesse/node_modules/.pnpm/vue-router@4.0.8_vue@3.0.11/node_modules/vue-router/dist/vue-router").RouteRecordRaw'.
    Type 'RouteRecordSingleView' is not assignable to type 'RouteRecordRaw'.
      Type 'RouteRecordSingleView' is not assignable to type 'RouteRecordMultipleViews'.
        Types of property 'components' are incompatible.
          Type 'undefined' is not assignable to type 'Record<string, RawRouteComponent>'.
```

Also the shim for import `App.vue` and similar Vue components is missing:
```
Cannot find module './App.vue' or its corresponding type declarations.ts(2307)
```

**Solutions:**
1. Use compatible Vuex version
2. Add shim defintion for vue import