### PR TITLE
chore: support blockquote dark mode & simplify markdown wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist-ssr
 node_modules
 # intellij stuff
 .idea/
+# logs
+*.log

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -18,4 +18,4 @@ function vitesse() {
 }
 ```
 
-Check out the [GitHub repo](https://github.com/antfu/vitesse) for more details.
+> Check out the [GitHub repo](https://github.com/antfu/vitesse) for more details.

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -25,6 +25,8 @@ html:not(.dark) {
   --prism-decorator: #bd8f8f;
   --prism-regex: #ab5e3f;
   --prism-json-property: #698c96;
+
+  --md-blockquote-color: #111827;
 }
 
 html.dark {
@@ -51,4 +53,10 @@ html.dark {
   --prism-line-number-gutter: #eeeeee;
   --prism-line-highlight-background: #444444;
   --prism-selection-background: #444444;
+
+  --md-blockquote-color: #e5e7eb;
+}
+
+.prose blockquote {
+  color: var(--md-blockquote-color);
 }

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -25,8 +25,6 @@ html:not(.dark) {
   --prism-decorator: #bd8f8f;
   --prism-regex: #ab5e3f;
   --prism-json-property: #698c96;
-
-  --md-blockquote-color: #111827;
 }
 
 html.dark {
@@ -53,10 +51,4 @@ html.dark {
   --prism-line-number-gutter: #eeeeee;
   --prism-line-highlight-background: #444444;
   --prism-selection-background: #444444;
-
-  --md-blockquote-color: #e5e7eb;
-}
-
-.prose blockquote {
-  color: var(--md-blockquote-color);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,8 @@ import Prism from 'markdown-it-prism'
 // @ts-expect-error missing types
 import LinkAttributes from 'markdown-it-link-attributes'
 
+const markdownWrapperClasses = 'prose prose-sm m-auto text-left'
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -34,7 +36,7 @@ export default defineConfig({
 
     // https://github.com/antfu/vite-plugin-md
     Markdown({
-      wrapperClasses: 'prose prose-sm m-auto text-left',
+      wrapperClasses: markdownWrapperClasses,
       headEnabled: true,
       markdownItSetup(md) {
         // https://prismjs.com/
@@ -75,7 +77,7 @@ export default defineConfig({
 
     // https://github.com/antfu/vite-plugin-windicss
     WindiCSS({
-      safelist: 'prose prose-sm m-auto text-left',
+      safelist: markdownWrapperClasses,
     }),
 
     // https://github.com/antfu/vite-plugin-pwa


### PR DESCRIPTION
- add dark mode for markdown `blockquote`
- set var `markdownWrapperClasses` for plugin Markdown `wrapperClasses` and WindiCSS `safelist`
- add `*.log` for `.gitignore` (Because `pnpm-debug.log` appears when `pnpm` installation failed)