### PR TITLE
chore: update vite-plugin-vue-i18n link

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -123,7 +123,7 @@ export default defineConfig({
       },
     }),
 
-    // https://github.com/intlify/vite-plugin-vue-i18n
+    // https://github.com/intlify/bundle-tools/tree/main/packages/vite-plugin-vue-i18n
     VueI18n({
       runtimeOnly: true,
       compositionOnly: true,


### PR DESCRIPTION
- https://github.com/intlify/vite-plugin-vue-i18n is deprecated and move to https://github.com/intlify/bundle-tools/tree/main/packages/vite-plugin-vue-i18n