### PR TITLE
fix: theme color flickering w/ critters

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,6 @@
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#00aba9">
   <meta name="msapplication-TileColor" content="#00aba9">
   <meta name="theme-color" content="#ffffff">
-</head>
-<body>
-  <div id="app"></div>
   <script>
     (function() {
       const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -19,6 +16,9 @@
         document.documentElement.classList.toggle('dark', true)
     })()
   </script>
+</head>
+<body>
+  <div id="app"></div>
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>


### PR DESCRIPTION
The script at the end of `<body>` to handle light/dark theming is called when the inlined CSS styles have already been loaded. This sometimes leads to flickering. 

With this change, the script to set theme mode will always be called first, since critter embeds the CSS at the end of `<head>`. What do you think?