### PR TITLE
Add nuxt like file based middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Mocking up web app with <b>Vitesse</b><sup><em>(speed)</em></sup><br>
 
 - 🗂 [File based routing](./src/pages)
 
+- 🚪 [Nuxt like middleware](./src/middleware)
+
 - 📦 [Components auto importing](./src/components)
 
 - 🍍 [State Management via Pinia](https://pinia.esm.dev/)

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,12 +20,12 @@ const routes = setupLayouts(generatedRoutes)
 export const createApp = ViteSSG(
   App,
   { routes },
-  async (ctx) => {
+  async(ctx) => {
     if (!ctx.isClient)
       await ctx.router.isReady()
 
     // install all modules under `modules/`
     Object.values(import.meta.globEager('./modules/*.ts')).map(i => i.install?.(ctx))
-    await import('./middleware').then(({ install }) => install?.(ctx))
+    await import('./middleware').then(({ install }) => install(ctx))
   },
 )

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,9 @@ const routes = setupLayouts(generatedRoutes)
 export const createApp = ViteSSG(
   App,
   { routes },
-  (ctx) => {
+  async (ctx) => {
+    // when we await the router, the routes don't resolve. Without this the middleware works as expected, throws error on build.
+    // await ctx.router.isReady()
     // install all modules under `modules/`
     Object.values(import.meta.globEager('./modules/*.ts')).map(i => i.install?.(ctx))
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,9 +21,11 @@ export const createApp = ViteSSG(
   App,
   { routes },
   async (ctx) => {
-    // when we await the router, the routes don't resolve. Without this the middleware works as expected, throws error on build.
-    // await ctx.router.isReady()
+    if (!ctx.isClient)
+      await ctx.router.isReady()
+
     // install all modules under `modules/`
     Object.values(import.meta.globEager('./modules/*.ts')).map(i => i.install?.(ctx))
+    await import('./middleware').then(({ install }) => install?.(ctx))
   },
 )

--- a/src/middleware/admin.ts
+++ b/src/middleware/admin.ts
@@ -1,6 +1,6 @@
 import { useUserStore } from '~/stores/user'
-const user = useUserStore()
 export default () => {
+  const user = useUserStore()
   if (user.savedName !== 'admin') {
     console.log('admin middleware failed, redirecting to index')
     return { name: 'index' }

--- a/src/middleware/admin.ts
+++ b/src/middleware/admin.ts
@@ -1,0 +1,8 @@
+import { useUserStore } from '~/stores/user'
+const user = useUserStore()
+export default () => {
+  if (user.savedName !== 'admin') {
+    console.log('admin middleware failed, redirecting to index')
+    return { name: 'index' }
+  }
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,8 @@
+import { useUserStore } from '~/stores/user'
+const user = useUserStore()
+export default () => {
+  if (!user.savedName) {
+    console.log('auth middleware failed, redirecting to index')
+    return { name: 'index' }
+  }
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import { useUserStore } from '~/stores/user'
-const user = useUserStore()
 export default () => {
+  const user = useUserStore()
   if (!user.savedName) {
     console.log('auth middleware failed, redirecting to index')
     return { name: 'index' }

--- a/src/middleware/example-global.ts
+++ b/src/middleware/example-global.ts
@@ -1,0 +1,4 @@
+export default () => {
+  console.log('global middleware fired')
+  // you may add an application wide check here, for example fetch the user if a jwt token is present but the user in the store is not populated.
+}

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -12,33 +12,28 @@ export const install: UserModule = ({ router }) => {
   // Load middleware modules dynamically.
   const globMiddleware = import.meta.globEager('./*.ts') as { [key: string]: MiddlewareModule }
   const middlewares: { [key: string]: Middleware } = {}
-  for (const name of Object.keys(globMiddleware)) {
+  for (const name of Object.keys(globMiddleware))
     middlewares[name.replace(/^\.\/|\.ts$/g, '')] = globMiddleware[name].default
-  }
 
-  router.beforeEach(async (to, from) => {
+  router.beforeEach(async(to, from) => {
     // Get the middleware for all the matched components.
     const middleware = [...globalMiddleware]
     to.matched.filter(record => record.meta && record.meta.middleware).forEach((record) => {
-      if (Array.isArray(record.meta.middleware)) {
+      if (Array.isArray(record.meta.middleware))
         middleware.push(...record.meta.middleware)
-      } else {
+      else
         middleware.push(record.meta.middleware as string)
-      }
     })
 
     // call each middleware
     for (const name of middleware) {
       const middlewareFn = middlewares[name]
-      if (!middlewareFn) {
+      if (!middlewareFn)
         throw new Error(`Undefined or invalid middleware [${name}]`)
-      }
       const response = await middlewareFn(to, from)
-      if (response === true || response === undefined) {
+      if (response === true || response === undefined)
         continue
-      }
       return response
     }
-
   })
 }

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,0 +1,44 @@
+import { RouteLocationNormalized } from 'vue-router'
+import { UserModule } from '~/types'
+
+type Middleware = (to: RouteLocationNormalized, from: RouteLocationNormalized) => RouteLocationNormalized | boolean
+interface MiddlewareModule {
+  default: Middleware
+}
+export const install: UserModule = ({ router }) => {
+  // The middleware for every page of the application.
+  const globalMiddleware = ['example-global']
+
+  // Load middleware modules dynamically.
+  const globMiddleware = import.meta.globEager('./*.ts') as { [key: string]: MiddlewareModule }
+  const middlewares: { [key: string]: Middleware } = {}
+  for (const name of Object.keys(globMiddleware)) {
+    middlewares[name.replace(/^\.\/|\.ts$/g, '')] = globMiddleware[name].default
+  }
+
+  router.beforeEach(async (to, from) => {
+    // Get the middleware for all the matched components.
+    const middleware = [...globalMiddleware]
+    to.matched.filter(record => record.meta && record.meta.middleware).forEach((record) => {
+      if (Array.isArray(record.meta.middleware)) {
+        middleware.push(...record.meta.middleware)
+      } else {
+        middleware.push(record.meta.middleware as string)
+      }
+    })
+
+    // call each middleware
+    for (const name of middleware) {
+      const middlewareFn = middlewares[name]
+      if (!middlewareFn) {
+        throw new Error(`Undefined or invalid middleware [${name}]`)
+      }
+      const response = await middlewareFn(to, from)
+      if (response === true || response === undefined) {
+        continue
+      }
+      return response
+    }
+
+  })
+}

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,7 +1,7 @@
 import { RouteLocationNormalized } from 'vue-router'
 import { UserModule } from '~/types'
 
-type Middleware = (to: RouteLocationNormalized, from: RouteLocationNormalized) => RouteLocationNormalized | boolean
+type Middleware = (to: RouteLocationNormalized, from: RouteLocationNormalized) => Promise<RouteLocationNormalized | boolean>
 interface MiddlewareModule {
   default: Middleware
 }

--- a/src/modules/pinia.ts
+++ b/src/modules/pinia.ts
@@ -1,5 +1,4 @@
 import { createPinia } from 'pinia'
-import { useUserStore } from '~/stores/user'
 import { UserModule } from '~/types'
 
 // Setup Pinia
@@ -15,15 +14,5 @@ export const install: UserModule = ({ isClient, initialState, app, router }) => 
 
   else
     initialState.pinia = pinia.state.value
-
-  router.beforeEach((to, from) => {
-    const user = useUserStore()
-    console.log('route middleware is running', to.meta.middleware)
-    if (to.meta.middleware === 'auth' && !user.savedName) {
-      console.log('route guard redirecting to index')
-      return { name: 'index' }
-    }
-    return true
-  })
 
 }

--- a/src/modules/pinia.ts
+++ b/src/modules/pinia.ts
@@ -3,7 +3,7 @@ import { UserModule } from '~/types'
 
 // Setup Pinia
 // https://pinia.esm.dev/
-export const install: UserModule = ({ isClient, initialState, app, router }) => {
+export const install: UserModule = ({ isClient, initialState, app }) => {
   const pinia = createPinia()
   app.use(pinia)
   // Refer to
@@ -14,5 +14,4 @@ export const install: UserModule = ({ isClient, initialState, app, router }) => 
 
   else
     initialState.pinia = pinia.state.value
-
 }

--- a/src/modules/pinia.ts
+++ b/src/modules/pinia.ts
@@ -1,9 +1,10 @@
 import { createPinia } from 'pinia'
+import { useUserStore } from '~/stores/user'
 import { UserModule } from '~/types'
 
 // Setup Pinia
 // https://pinia.esm.dev/
-export const install: UserModule = ({ isClient, initialState, app }) => {
+export const install: UserModule = ({ isClient, initialState, app, router }) => {
   const pinia = createPinia()
   app.use(pinia)
   // Refer to
@@ -14,4 +15,15 @@ export const install: UserModule = ({ isClient, initialState, app }) => {
 
   else
     initialState.pinia = pinia.state.value
+
+  router.beforeEach((to, from) => {
+    const user = useUserStore()
+    console.log('route middleware is running', to.meta.middleware)
+    if (to.meta.middleware === 'auth' && !user.savedName) {
+      console.log('route guard redirecting to index')
+      return { name: 'index' }
+    }
+    return true
+  })
+
 }

--- a/src/pages/adminonly.vue
+++ b/src/pages/adminonly.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { useUserStore } from '~/stores/user'
+
+const user = useUserStore()
+const name = ref(user.savedName)
+</script>
+
+<template>
+  <div>
+    <p class="text-4xl">
+      <carbon-campsite class="inline-block" />
+    </p>
+    <p>
+      <a rel="noreferrer" href="https://github.com/antfu/vitesse" target="_blank">
+        Vitesse
+      </a>
+    </p>
+    <p>
+      <em class="text-sm opacity-75">This is an admin only page, that you can access only with the admin username.</em>
+    </p>
+
+    <div class="py-4" />
+
+    <div>
+      <router-link
+        class="btn m-3 text-sm mt-6"
+        to="/"
+      >
+        Home
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<route lang="yaml">
+meta:
+  middleware:
+    - auth
+    - admin
+</route>

--- a/src/pages/authonly.vue
+++ b/src/pages/authonly.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { useUserStore } from '~/stores/user'
+
+const user = useUserStore()
+const name = ref(user.savedName)
+</script>
+
+<template>
+  <div>
+    <p class="text-4xl">
+      <carbon-campsite class="inline-block" />
+    </p>
+    <p>
+      <a rel="noreferrer" href="https://github.com/antfu/vitesse" target="_blank">
+        Vitesse
+      </a>
+    </p>
+    <p>
+      <em class="text-sm opacity-75">This is an auth only page. Try navigating to it without first setting a user.</em>
+    </p>
+
+    <div class="py-4" />
+
+    <div>
+      <router-link
+        class="btn m-3 text-sm mt-6"
+        to="/"
+      >
+        Home
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<route lang="yaml">
+meta:
+  middleware: auth
+</route>

--- a/src/pages/hi/[name].vue
+++ b/src/pages/hi/[name].vue
@@ -38,6 +38,14 @@ watchEffect(() => {
     </template>
 
     <div>
+      <router-link
+        class="btn m-3 text-sm mt-6"
+        to="/authonly"
+      >
+        Auth Only Page
+      </router-link>
+    </div>
+    <div>
       <button
         class="btn m-3 text-sm mt-6"
         @click="router.back()"

--- a/src/pages/hi/[name].vue
+++ b/src/pages/hi/[name].vue
@@ -44,6 +44,12 @@ watchEffect(() => {
       >
         Auth Only Page
       </router-link>
+      <router-link
+        class="btn m-3 text-sm mt-6"
+        to="/adminonly"
+      >
+        Admin Only Page
+      </router-link>
     </div>
     <div>
       <button

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -62,6 +62,12 @@ const { t } = useI18n()
       >
         Auth Only Page
       </router-link>
+      <router-link
+        class="btn m-3 text-sm mt-6"
+        to="/adminonly"
+      >
+        Admin Only Page
+      </router-link>
     </div>
   </div>
 </template>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -55,6 +55,14 @@ const { t } = useI18n()
         {{ t('button.go') }}
       </button>
     </div>
+    <div>
+      <router-link
+        class="btn m-3 text-sm mt-6"
+        to="/authonly"
+      >
+        Auth Only Page
+      </router-link>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
Hi, I wanted to implement nuxt like file-based middleware. Had to install the module after all the other modules for pinia to become available, so added the install after the `globEager` install in `main.ts`. If there is a better alternative I'd be happy your thoughts.
 
Also added the `router.isReady` await before those installs, in client mode as we discussed [here](https://github.com/antfu/vite-ssg/issues/103).
 
I also placed the middleware module install within `middleware/index.ts` which doesn't fit very well with the rest of the project structure, also open to suggestions here.