### PR TITLE
fix: formatOnSave not disabled in workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,5 @@
   "files.associations": {
     "*.css": "postcss",
   },
+  "editor.formatOnSave": false,
 }


### PR DESCRIPTION
I was testing out this template and noticed some fighting in VSCode in my editor. I had `editor.formatOnSave` on true in my global settings, and as this was not disabled in the workspace first ESlint did its autoformatting and after that VSCode did it's formatting. This causes issues with spacing/tabs etc.

Explicitely disabling this settings in the template will prevent this from happening :)