### PR TITLE
docs: add new vitesse community variation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ As this template is strongly opinionated, the following provides a curated list 
 - [vitailse](https://github.com/zynth17/vitailse) by [@zynth17](https://github.com/zynth17) - Like Vitesse but with TailwindCSS
 - [vitesse-modernized-chrome-ext](https://github.com/xiaoluoboding/vitesse-modernized-chrome-ext) by [@xiaoluoboding](https://github.com/xiaoluoboding) - ⚡️ Modernized Chrome Extension Manifest V3 Vite Starter Template
 - [vitesse-stackter-clean-architect](https://github.com/shamscorner/vitesse-stackter-clean-architect) by [@shamscorner](https://github.com/shamscorner) - A modular clean architecture pattern in vitesse template
+- [vitesse-enterprise](https://github.com/FranciscoKloganB/vitesse-enterprise) by [@FranciscoKloganB](https://github.com/FranciscoKloganB) - It combines `vitesse-stackter` with strict styling guides and component testing, enriched with pre-commit and pre-push hooks.
 
 ## Try it now!
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ As this template is strongly opinionated, the following provides a curated list 
 - [vitailse](https://github.com/zynth17/vitailse) by [@zynth17](https://github.com/zynth17) - Like Vitesse but with TailwindCSS
 - [vitesse-modernized-chrome-ext](https://github.com/xiaoluoboding/vitesse-modernized-chrome-ext) by [@xiaoluoboding](https://github.com/xiaoluoboding) - ⚡️ Modernized Chrome Extension Manifest V3 Vite Starter Template
 - [vitesse-stackter-clean-architect](https://github.com/shamscorner/vitesse-stackter-clean-architect) by [@shamscorner](https://github.com/shamscorner) - A modular clean architecture pattern in vitesse template
-- [vitesse-enterprise](https://github.com/FranciscoKloganB/vitesse-enterprise) by [@FranciscoKloganB](https://github.com/FranciscoKloganB) - It combines `vitesse-stackter` with strict styling guides and component testing, enriched with pre-commit and pre-push hooks.
+- [vitesse-enterprise](https://github.com/FranciscoKloganB/vitesse-enterprise) by [@FranciscoKloganB](https://github.com/FranciscoKloganB) - Consistent coding styles regardless of team-size.
 
 ## Try it now!
 


### PR DESCRIPTION
This pull request proposes to reference my own variation of `vitesse` and `vitesse-stackter-clean-architect` and focuses on adding strong out of the box linting and formatting.

Code style is verified on pre-commit. Component and E2E tests run on-pre-push.

As a bonus, the pull request also adds bug, user story and pull request templates for github. These are also added for gitlab with a gitlab CI/CD script.