### PR TITLE
chore: add vue shims for better eslint linting

### DIFF
--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -8,3 +8,8 @@ declare module '*.md' {
   const component: ComponentOptions
   export default component
 }
+
+declare module '*.vue' {
+  import Vue from 'vue'
+  export default Vue
+}


### PR DESCRIPTION
Helps get rid of eslint error when importing Vue components from relative path. It happens for example in `main.js` where:

```
import App from './App.vue'
```
gives us an error, stating `Cannot find module './App.vue' or its corresponding type declarations.ts(2307)`. Hope it gets merged.