### PR TITLE
fix: pass BASE_URL to ViteSSG

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ const routes = setupLayouts(generatedRoutes)
 // https://github.com/antfu/vite-ssg
 export const createApp = ViteSSG(
   App,
-  { routes },
+  { routes, base: import.meta.env.BASE_URL },
   (ctx) => {
     // install all modules under `modules/`
     Object.values(import.meta.globEager('./modules/*.ts')).map(i => i.install?.(ctx))


### PR DESCRIPTION
In the current setup, we don't pass the `base` property to the `RouterOptions` in the `ViteSSG` function. The result is that [vite-plugin-pages](https://github.com/hannoeru/vite-plugin-pages) will not work when a base URL is set in the `vite.config.ts` file. 