### PR TITLE
chore: remove @vue/{compiler-sfc, server-renderer}

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "nprogress": "^0.2.0",
     "pinia": "^2.0.9",
     "prism-theme-vars": "^0.2.2",
-    "vue": "^3.2.26",
+    "vue": "^3.2.28",
     "vue-demi": "^0.12.1",
     "vue-i18n": "^9.1.9",
     "vue-router": "^4.0.12"
@@ -29,8 +29,6 @@
     "@types/markdown-it-link-attributes": "^3.0.1",
     "@types/nprogress": "^0.2.0",
     "@vitejs/plugin-vue": "^2.0.1",
-    "@vue/compiler-sfc": "^3.2.26",
-    "@vue/server-renderer": "^3.2.26",
     "@vue/test-utils": "^2.0.0-rc.18",
     "critters": "^0.0.16",
     "cross-env": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,6 @@ specifiers:
   '@types/markdown-it-link-attributes': ^3.0.1
   '@types/nprogress': ^0.2.0
   '@vitejs/plugin-vue': ^2.0.1
-  '@vue/compiler-sfc': ^3.2.26
-  '@vue/server-renderer': ^3.2.26
   '@vue/test-utils': ^2.0.0-rc.18
   '@vueuse/core': ^7.5.3
   '@vueuse/head': ^0.7.4
@@ -37,22 +35,22 @@ specifiers:
   vite-plugin-windicss: ^1.6.2
   vite-ssg: ^0.17.6
   vitest: ^0.1.13
-  vue: ^3.2.26
+  vue: ^3.2.28
   vue-demi: ^0.12.1
   vue-i18n: ^9.1.9
   vue-router: ^4.0.12
   vue-tsc: ^0.30.2
 
 dependencies:
-  '@vueuse/core': 7.5.3_vue@3.2.26
-  '@vueuse/head': 0.7.4_vue@3.2.26
+  '@vueuse/core': 7.5.3_vue@3.2.28
+  '@vueuse/head': 0.7.4_vue@3.2.28
   nprogress: 0.2.0
-  pinia: 2.0.9_typescript@4.5.4+vue@3.2.26
+  pinia: 2.0.9_typescript@4.5.4+vue@3.2.28
   prism-theme-vars: 0.2.2
-  vue: 3.2.26
-  vue-demi: 0.12.1_vue@3.2.26
-  vue-i18n: 9.1.9_vue@3.2.26
-  vue-router: 4.0.12_vue@3.2.26
+  vue: 3.2.28
+  vue-demi: 0.12.1_vue@3.2.28
+  vue-i18n: 9.1.9_vue@3.2.28
+  vue-router: 4.0.12_vue@3.2.28
 
 devDependencies:
   '@antfu/eslint-config': 0.16.0_eslint@8.6.0+typescript@4.5.4
@@ -60,10 +58,8 @@ devDependencies:
   '@intlify/vite-plugin-vue-i18n': 3.2.1_vite@2.7.12+vue-i18n@9.1.9
   '@types/markdown-it-link-attributes': 3.0.1
   '@types/nprogress': 0.2.0
-  '@vitejs/plugin-vue': 2.0.1_vite@2.7.12+vue@3.2.26
-  '@vue/compiler-sfc': 3.2.26
-  '@vue/server-renderer': 3.2.26_vue@3.2.26
-  '@vue/test-utils': 2.0.0-rc.18_vue@3.2.26
+  '@vitejs/plugin-vue': 2.0.1_vite@2.7.12+vue@3.2.28
+  '@vue/test-utils': 2.0.0-rc.18_vue@3.2.28
   critters: 0.0.16
   cross-env: 7.0.3
   cypress: 9.2.1
@@ -75,16 +71,16 @@ devDependencies:
   pnpm: 6.26.1
   typescript: 4.5.4
   unplugin-auto-import: 0.5.10_@vueuse+core@7.5.3+vite@2.7.12
-  unplugin-icons: 0.13.0_8e7a794d2c1f1ff5ff6eb4ae771e4ef1
-  unplugin-vue-components: 0.17.11_vite@2.7.12+vue@3.2.26
+  unplugin-icons: 0.13.0_vite@2.7.12
+  unplugin-vue-components: 0.17.11_vite@2.7.12+vue@3.2.28
   vite: 2.7.12
   vite-plugin-inspect: 0.3.13_vite@2.7.12
   vite-plugin-md: 0.11.7_vite@2.7.12
-  vite-plugin-pages: 0.20.0_8e7a794d2c1f1ff5ff6eb4ae771e4ef1
+  vite-plugin-pages: 0.20.0_vite@2.7.12
   vite-plugin-pwa: 0.11.13_vite@2.7.12
-  vite-plugin-vue-layouts: 0.5.0_adba8b57b8e4307cab9bc1f5bc19737b
+  vite-plugin-vue-layouts: 0.5.0_37b1dfec4ff363ea9980be8d35f819f2
   vite-plugin-windicss: 1.6.2_vite@2.7.12
-  vite-ssg: 0.17.6_0b7aeac23451430d7a0b62007ee02bfe
+  vite-ssg: 0.17.6_6b0860dd26abf4921731beb4b1ae1a2d
   vitest: 0.1.13
   vue-tsc: 0.30.2_typescript@4.5.4
 
@@ -1422,7 +1418,7 @@ packages:
       '@intlify/shared': 9.2.0-beta.28
       jsonc-eslint-parser: 1.4.1
       source-map: 0.6.1
-      vue-i18n: 9.1.9_vue@3.2.26
+      vue-i18n: 9.1.9_vue@3.2.28
       yaml-eslint-parser: 0.3.2
     dev: true
 
@@ -1506,7 +1502,7 @@ packages:
       fast-glob: 3.2.7
       source-map: 0.6.1
       vite: 2.7.12
-      vue-i18n: 9.1.9_vue@3.2.26
+      vue-i18n: 9.1.9_vue@3.2.28
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1852,7 +1848,7 @@ packages:
       eslint-visitor-keys: 3.1.0
     dev: true
 
-  /@vitejs/plugin-vue/2.0.1_vite@2.7.12+vue@3.2.26:
+  /@vitejs/plugin-vue/2.0.1_vite@2.7.12+vue@3.2.28:
     resolution: {integrity: sha512-wtdMnGVvys9K8tg+DxowU1ytTrdVveXr3LzdhaKakysgGXyrsfaeds2cDywtvujEASjWOwWL/OgWM+qoeM8Plg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1860,7 +1856,7 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 2.7.12
-      vue: 3.2.26
+      vue: 3.2.28
     dev: true
 
   /@volar/code-gen/0.30.2:
@@ -1907,9 +1903,9 @@ packages:
       '@volar/code-gen': 0.30.2
       '@volar/shared': 0.30.2
       '@volar/source-map': 0.30.2
-      '@vue/compiler-core': 3.2.26
-      '@vue/compiler-dom': 3.2.26
-      '@vue/shared': 3.2.26
+      '@vue/compiler-core': 3.2.28
+      '@vue/compiler-dom': 3.2.28
+      '@vue/shared': 3.2.28
       upath: 2.0.1
     dev: true
 
@@ -1931,12 +1927,28 @@ packages:
       '@vue/shared': 3.2.26
       estree-walker: 2.0.2
       source-map: 0.6.1
+    dev: true
+
+  /@vue/compiler-core/3.2.28:
+    resolution: {integrity: sha512-mQpfEjmHVxmWKaup0HL6tLMv2HqjjJu7XT4/q0IoUXYXC4xKG8lIVn5YChJqxBTLPuQjzas7u7i9L4PAWJZRtA==}
+    dependencies:
+      '@babel/parser': 7.16.6
+      '@vue/shared': 3.2.28
+      estree-walker: 2.0.2
+      source-map: 0.6.1
 
   /@vue/compiler-dom/3.2.26:
     resolution: {integrity: sha512-smBfaOW6mQDxcT3p9TKT6mE22vjxjJL50GFVJiI0chXYGU/xzC05QRGrW3HHVuJrmLTLx5zBhsZ2dIATERbarg==}
     dependencies:
       '@vue/compiler-core': 3.2.26
       '@vue/shared': 3.2.26
+    dev: true
+
+  /@vue/compiler-dom/3.2.28:
+    resolution: {integrity: sha512-KA4yXceLteKC7VykvPnViUixemQw3A+oii+deSbZJOQKQKVh1HLosI10qxa8ImPCyun41+wG3uGR+tW7eu1W6Q==}
+    dependencies:
+      '@vue/compiler-core': 3.2.28
+      '@vue/shared': 3.2.28
 
   /@vue/compiler-sfc/3.2.26:
     resolution: {integrity: sha512-ePpnfktV90UcLdsDQUh2JdiTuhV0Skv2iYXxfNMOK/F3Q+2BO0AulcVcfoksOpTJGmhhfosWfMyEaEf0UaWpIw==}
@@ -1951,12 +1963,36 @@ packages:
       magic-string: 0.25.7
       postcss: 8.4.4
       source-map: 0.6.1
+    dev: true
+
+  /@vue/compiler-sfc/3.2.28:
+    resolution: {integrity: sha512-zB0WznfEBb4CbGBHzhboHDKVO5nxbkbxxFo9iVlxObP7a9/qvA5kkZEuT7nXP52f3b3qEfmVTjIT23Lo1ndZdQ==}
+    dependencies:
+      '@babel/parser': 7.16.6
+      '@vue/compiler-core': 3.2.28
+      '@vue/compiler-dom': 3.2.28
+      '@vue/compiler-ssr': 3.2.28
+      '@vue/reactivity-transform': 3.2.28
+      '@vue/shared': 3.2.28
+      estree-walker: 2.0.2
+      magic-string: 0.25.7
+      postcss: 8.4.5
+      source-map: 0.6.1
+    dev: false
 
   /@vue/compiler-ssr/3.2.26:
     resolution: {integrity: sha512-2mywLX0ODc4Zn8qBoA2PDCsLEZfpUGZcyoFRLSOjyGGK6wDy2/5kyDOWtf0S0UvtoyVq95OTSGIALjZ4k2q/ag==}
     dependencies:
       '@vue/compiler-dom': 3.2.26
       '@vue/shared': 3.2.26
+    dev: true
+
+  /@vue/compiler-ssr/3.2.28:
+    resolution: {integrity: sha512-z8rck1PDTu20iLyip9lAvIhaO40DUJrw3Zv0mS4Apfh3PlfWpF5dhsO5g0dgt213wgYsQIYVIlU9cfrYapqRgg==}
+    dependencies:
+      '@vue/compiler-dom': 3.2.28
+      '@vue/shared': 3.2.28
+    dev: false
 
   /@vue/devtools-api/6.0.0-beta.18:
     resolution: {integrity: sha512-56vRhO7nXWWFYTx520BQSDlQH5VYpwy62hFDEqi2yHHEBpEqseOP5WYQusq7BEW3DXSY9E9cfPVR5CFtJbKuMg==}
@@ -1978,48 +2014,71 @@ packages:
       '@vue/shared': 3.2.26
       estree-walker: 2.0.2
       magic-string: 0.25.7
+    dev: true
+
+  /@vue/reactivity-transform/3.2.28:
+    resolution: {integrity: sha512-zE8idNkOPnBDd2tKSIk84hOQZ+jXKvSy5FoIIVlcNEJHnCFnQ3maqeSJ9KoB2Rf6EXUhFTiTDNRlYlXmT2uHbQ==}
+    dependencies:
+      '@babel/parser': 7.16.6
+      '@vue/compiler-core': 3.2.28
+      '@vue/shared': 3.2.28
+      estree-walker: 2.0.2
+      magic-string: 0.25.7
+    dev: false
 
   /@vue/reactivity/3.2.26:
     resolution: {integrity: sha512-h38bxCZLW6oFJVDlCcAiUKFnXI8xP8d+eO0pcDxx+7dQfSPje2AO6M9S9QO6MrxQB7fGP0DH0dYQ8ksf6hrXKQ==}
     dependencies:
       '@vue/shared': 3.2.26
+    dev: true
 
-  /@vue/runtime-core/3.2.26:
-    resolution: {integrity: sha512-BcYi7qZ9Nn+CJDJrHQ6Zsmxei2hDW0L6AB4vPvUQGBm2fZyC0GXd/4nVbyA2ubmuhctD5RbYY8L+5GUJszv9mQ==}
+  /@vue/reactivity/3.2.28:
+    resolution: {integrity: sha512-WamM5LGv7JIarW+EYAzYFqYonZXjTnOjNW0sBO93jRE9I1ReAwfH8NvQXkPA3JZ3fuF6SGDdG8Y9/+dKjd/1Gw==}
     dependencies:
-      '@vue/reactivity': 3.2.26
-      '@vue/shared': 3.2.26
+      '@vue/shared': 3.2.28
     dev: false
 
-  /@vue/runtime-dom/3.2.26:
-    resolution: {integrity: sha512-dY56UIiZI+gjc4e8JQBwAifljyexfVCkIAu/WX8snh8vSOt/gMSEGwPRcl2UpYpBYeyExV8WCbgvwWRNt9cHhQ==}
+  /@vue/runtime-core/3.2.28:
+    resolution: {integrity: sha512-sVbBMFUt42JatTlXbdH6tVcLPw1eEOrrVQWI+j6/nJVzR852RURaT6DhdR0azdYscxq4xmmBctE0VQmlibBOFw==}
     dependencies:
-      '@vue/runtime-core': 3.2.26
-      '@vue/shared': 3.2.26
+      '@vue/reactivity': 3.2.28
+      '@vue/shared': 3.2.28
+    dev: false
+
+  /@vue/runtime-dom/3.2.28:
+    resolution: {integrity: sha512-Jg7cxZanEXXGu1QnZILFLnDrM+MIFN8VAullmMZiJEZziHvhygRMpi0ahNy/8OqGwtTze1JNhLdHRBO+q2hbmg==}
+    dependencies:
+      '@vue/runtime-core': 3.2.28
+      '@vue/shared': 3.2.28
       csstype: 2.6.18
     dev: false
 
-  /@vue/server-renderer/3.2.26_vue@3.2.26:
-    resolution: {integrity: sha512-Jp5SggDUvvUYSBIvYEhy76t4nr1vapY/FIFloWmQzn7UxqaHrrBpbxrqPcTrSgGrcaglj0VBp22BKJNre4aA1w==}
+  /@vue/server-renderer/3.2.28_vue@3.2.28:
+    resolution: {integrity: sha512-S+MhurgkPabRvhdDl8R6efKBmniJqBbbWIYTXADaJIKFLFLQCW4gcYUTbxuebzk6j3z485vpekhrHHymTF52Pg==}
     peerDependencies:
-      vue: 3.2.26
+      vue: 3.2.28
     dependencies:
-      '@vue/compiler-ssr': 3.2.26
-      '@vue/shared': 3.2.26
-      vue: 3.2.26
+      '@vue/compiler-ssr': 3.2.28
+      '@vue/shared': 3.2.28
+      vue: 3.2.28
+    dev: false
 
   /@vue/shared/3.2.26:
     resolution: {integrity: sha512-vPV6Cq+NIWbH5pZu+V+2QHE9y1qfuTq49uNWw4f7FDEeZaDU2H2cx5jcUZOAKW7qTrUS4k6qZPbMy1x4N96nbA==}
+    dev: true
 
-  /@vue/test-utils/2.0.0-rc.18_vue@3.2.26:
+  /@vue/shared/3.2.28:
+    resolution: {integrity: sha512-eMQ8s9j8FpbGHlgUAaj/coaG3Q8YtMsoWL/RIHTsE3Ex7PUTyr7V91vB5HqWB5Sn8m4RXTHGO22/skoTUYvp0A==}
+
+  /@vue/test-utils/2.0.0-rc.18_vue@3.2.28:
     resolution: {integrity: sha512-aifolXjVdsogjaLmDoZ0FU8vN+R67aWmg9OuVeED4w5Ij5GFQLrlhM19uhWe/r5xXUL4fXMk3pX5wW6FJP1NcQ==}
     peerDependencies:
       vue: ^3.0.1
     dependencies:
-      vue: 3.2.26
+      vue: 3.2.28
     dev: true
 
-  /@vueuse/core/7.5.3_vue@3.2.26:
+  /@vueuse/core/7.5.3_vue@3.2.28:
     resolution: {integrity: sha512-D9j5ymHFMFRXQqCp0yZJkf/bvBGiz0MrKUa364p+L8dMyd5zyq2K1JmHyvoBd4xbTFRfmQ1h878u6YE5LCkDVQ==}
     peerDependencies:
       '@vue/composition-api': ^1.1.0
@@ -2030,20 +2089,20 @@ packages:
       vue:
         optional: true
     dependencies:
-      '@vueuse/shared': 7.5.3_vue@3.2.26
-      vue: 3.2.26
-      vue-demi: 0.12.1_vue@3.2.26
+      '@vueuse/shared': 7.5.3_vue@3.2.28
+      vue: 3.2.28
+      vue-demi: 0.12.1_vue@3.2.28
     dev: false
 
-  /@vueuse/head/0.7.4_vue@3.2.26:
+  /@vueuse/head/0.7.4_vue@3.2.28:
     resolution: {integrity: sha512-cmps+wrdgL77V72vtjU6kaAunkG6GhswaMIQoh7Twc52ql4/p7i1Amd31LqnnvNF/bfuvzcXgYvsH8I7kimZmA==}
     peerDependencies:
       vue: '>=3'
     dependencies:
-      vue: 3.2.26
+      vue: 3.2.28
     dev: false
 
-  /@vueuse/shared/7.5.3_vue@3.2.26:
+  /@vueuse/shared/7.5.3_vue@3.2.28:
     resolution: {integrity: sha512-BJ71cxHN5VByW1S58Gl85NFJaQu93F7Vs7K/MuAKsIIuHm9PBbkR5Vxkg9ko9cBdiKVt+FNoo13BhdbA+Vwycg==}
     peerDependencies:
       '@vue/composition-api': ^1.1.0
@@ -2054,8 +2113,8 @@ packages:
       vue:
         optional: true
     dependencies:
-      vue: 3.2.26
-      vue-demi: 0.12.1_vue@3.2.26
+      vue: 3.2.28
+      vue-demi: 0.12.1_vue@3.2.28
     dev: false
 
   /@windicss/config/1.6.2:
@@ -5514,7 +5573,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /pinia/2.0.9_typescript@4.5.4+vue@3.2.26:
+  /pinia/2.0.9_typescript@4.5.4+vue@3.2.28:
     resolution: {integrity: sha512-iuYdxLJKQ07YPyOHYH05wNG9eKWqkP/4y4GE8+RqEYtz5fwHgPA5kr6zQbg/DoEJGnR2XCm1w1vdt6ppzL9ATg==}
     peerDependencies:
       '@vue/composition-api': ^1.4.0
@@ -5528,8 +5587,8 @@ packages:
     dependencies:
       '@vue/devtools-api': 6.0.0-beta.21.1
       typescript: 4.5.4
-      vue: 3.2.26
-      vue-demi: 0.12.1_vue@3.2.26
+      vue: 3.2.28
+      vue-demi: 0.12.1_vue@3.2.28
     dev: false
 
   /pluralize/8.0.0:
@@ -5550,6 +5609,7 @@ packages:
       nanoid: 3.1.30
       picocolors: 1.0.0
       source-map-js: 1.0.1
+    dev: true
 
   /postcss/8.4.5:
     resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
@@ -5558,7 +5618,6 @@ packages:
       nanoid: 3.1.30
       picocolors: 1.0.0
       source-map-js: 1.0.1
-    dev: true
 
   /prelude-ls/1.1.2:
     resolution: {integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=}
@@ -6670,7 +6729,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.4.0
       '@rollup/pluginutils': 4.1.2
-      '@vueuse/core': 7.5.3_vue@3.2.26
+      '@vueuse/core': 7.5.3_vue@3.2.28
       local-pkg: 0.4.1
       magic-string: 0.25.7
       resolve: 1.21.0
@@ -6682,7 +6741,7 @@ packages:
       - webpack
     dev: true
 
-  /unplugin-icons/0.13.0_8e7a794d2c1f1ff5ff6eb4ae771e4ef1:
+  /unplugin-icons/0.13.0_vite@2.7.12:
     resolution: {integrity: sha512-CyAl0HV3bZUGT7ut9agpPRhEYXCvufr80Fh72yrkD57BVCTZ7ze10Rt63ZrvPXiJQpd+aI/Bizm2aqOf3WPSfg==}
     peerDependencies:
       '@svgr/core': ^5.5.0
@@ -6702,7 +6761,6 @@ packages:
       '@antfu/install-pkg': 0.1.0
       '@antfu/utils': 0.4.0
       '@iconify/utils': 1.0.20
-      '@vue/compiler-sfc': 3.2.26
       debug: 4.3.3
       kolorist: 1.5.1
       local-pkg: 0.4.0
@@ -6714,7 +6772,7 @@ packages:
       - webpack
     dev: true
 
-  /unplugin-vue-components/0.17.11_vite@2.7.12+vue@3.2.26:
+  /unplugin-vue-components/0.17.11_vite@2.7.12+vue@3.2.28:
     resolution: {integrity: sha512-u5MQ0TbikszRelCt6EA/HskGtGkGLDxi7tQ4/4tcEPWkH3yXSZRJCOeLF5MSdxN1SiGjaJ0I9zeHjoZFC3FvRw==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -6737,7 +6795,7 @@ packages:
       minimatch: 3.0.4
       resolve: 1.20.0
       unplugin: 0.2.21_vite@2.7.12
-      vue: 3.2.26
+      vue: 3.2.28
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -6884,7 +6942,7 @@ packages:
       vite: 2.7.12
     dev: true
 
-  /vite-plugin-pages/0.20.0_8e7a794d2c1f1ff5ff6eb4ae771e4ef1:
+  /vite-plugin-pages/0.20.0_vite@2.7.12:
     resolution: {integrity: sha512-yM+8ORpssLknR59HL26kz2g7BU79CGkgyw28rLpsbpjX7GgYBDgTHp4llMrpRD8JAeJBndP7CdUmpBM3ReG4Sw==}
     peerDependencies:
       '@vue/compiler-sfc': '>=3'
@@ -6893,7 +6951,6 @@ packages:
       '@vue/compiler-sfc':
         optional: true
     dependencies:
-      '@vue/compiler-sfc': 3.2.26
       debug: 4.3.3
       deep-equal: 2.0.5
       fast-glob: 3.2.10
@@ -6922,7 +6979,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-vue-layouts/0.5.0_adba8b57b8e4307cab9bc1f5bc19737b:
+  /vite-plugin-vue-layouts/0.5.0_37b1dfec4ff363ea9980be8d35f819f2:
     resolution: {integrity: sha512-KN03GMSGNrWxeHJo5OO9fvdZh44PfievNAoLeMbf20UQPBBO6kpIMVTYB6sFPMWmiTbqZmq3we4z/ocJkxAEiA==}
     peerDependencies:
       vite: ^2.5.0
@@ -6933,8 +6990,8 @@ packages:
       debug: 4.3.2
       fast-glob: 3.2.7
       vite: 2.7.12
-      vue: 3.2.26
-      vue-router: 4.0.12_vue@3.2.26
+      vue: 3.2.28
+      vue-router: 4.0.12_vue@3.2.28
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6953,7 +7010,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-ssg/0.17.6_0b7aeac23451430d7a0b62007ee02bfe:
+  /vite-ssg/0.17.6_6b0860dd26abf4921731beb4b1ae1a2d:
     resolution: {integrity: sha512-ZOu67Y2bAH4g3IyBCfWIYPRbawEjGwrxcQX9jew9Iw20z92+Pic9ztcsbCLgnHRpQRWmQ2K//xiXoHxqCPhzHg==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -6967,7 +7024,7 @@ packages:
       critters:
         optional: true
     dependencies:
-      '@vueuse/head': 0.7.4_vue@3.2.26
+      '@vueuse/head': 0.7.4_vue@3.2.28
       critters: 0.0.16
       fs-extra: 10.0.0
       html-minifier: 4.0.0
@@ -6975,8 +7032,8 @@ packages:
       kolorist: 1.5.1
       prettier: 2.5.1
       vite: 2.7.12
-      vue: 3.2.26
-      vue-router: 4.0.12_vue@3.2.26
+      vue: 3.2.28
+      vue-router: 4.0.12_vue@3.2.28
       yargs: 17.3.1
     transitivePeerDependencies:
       - bufferutil
@@ -7152,7 +7209,7 @@ packages:
       '@volar/vue-code-gen': 0.30.2
       '@vscode/emmet-helper': 2.8.3
       '@vue/reactivity': 3.2.26
-      '@vue/shared': 3.2.26
+      '@vue/shared': 3.2.28
       request-light: 0.5.7
       upath: 2.0.1
       vscode-css-languageservice: 5.1.9
@@ -7165,7 +7222,7 @@ packages:
       vscode-typescript-languageservice: 0.30.2
     dev: true
 
-  /vue-demi/0.12.1_vue@3.2.26:
+  /vue-demi/0.12.1_vue@3.2.28:
     resolution: {integrity: sha512-QL3ny+wX8c6Xm1/EZylbgzdoDolye+VpCXRhI2hug9dJTP3OUJ3lmiKN3CsVV3mOJKwFi0nsstbgob0vG7aoIw==}
     engines: {node: '>=12'}
     hasBin: true
@@ -7177,7 +7234,7 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.2.26
+      vue: 3.2.28
     dev: false
 
   /vue-eslint-parser/8.0.1_eslint@8.6.0:
@@ -7198,7 +7255,7 @@ packages:
       - supports-color
     dev: true
 
-  /vue-i18n/9.1.9_vue@3.2.26:
+  /vue-i18n/9.1.9_vue@3.2.28:
     resolution: {integrity: sha512-JeRdNVxS2OGp1E+pye5XB6+M6BBkHwAv9C80Q7+kzoMdUDGRna06tjC0vCB/jDX9aWrl5swxOMFcyAr7or8XTA==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -7208,16 +7265,16 @@ packages:
       '@intlify/shared': 9.1.9
       '@intlify/vue-devtools': 9.1.9
       '@vue/devtools-api': 6.0.0-beta.18
-      vue: 3.2.26
+      vue: 3.2.28
     dev: false
 
-  /vue-router/4.0.12_vue@3.2.26:
+  /vue-router/4.0.12_vue@3.2.28:
     resolution: {integrity: sha512-CPXvfqe+mZLB1kBWssssTiWg4EQERyqJZes7USiqfW9B5N2x+nHlnsM1D3b5CaJ6qgCvMmYJnz+G0iWjNCvXrg==}
     peerDependencies:
       vue: ^3.0.0
     dependencies:
       '@vue/devtools-api': 6.0.0-beta.19
-      vue: 3.2.26
+      vue: 3.2.28
     dev: false
 
   /vue-tsc/0.30.2_typescript@4.5.4:
@@ -7231,14 +7288,14 @@ packages:
       vscode-vue-languageservice: 0.30.2
     dev: true
 
-  /vue/3.2.26:
-    resolution: {integrity: sha512-KD4lULmskL5cCsEkfhERVRIOEDrfEL9CwAsLYpzptOGjaGFNWo3BQ9g8MAb7RaIO71rmVOziZ/uEN/rHwcUIhg==}
+  /vue/3.2.28:
+    resolution: {integrity: sha512-U+jBwVh3RQ9AgceLFdT7i2FFujoC+kYuGrKo5y8aLluWKZWPS40WgA2pyYHaiSX9ydCbEGr3rc/JzdqskzD95g==}
     dependencies:
-      '@vue/compiler-dom': 3.2.26
-      '@vue/compiler-sfc': 3.2.26
-      '@vue/runtime-dom': 3.2.26
-      '@vue/server-renderer': 3.2.26_vue@3.2.26
-      '@vue/shared': 3.2.26
+      '@vue/compiler-dom': 3.2.28
+      '@vue/compiler-sfc': 3.2.28
+      '@vue/runtime-dom': 3.2.28
+      '@vue/server-renderer': 3.2.28_vue@3.2.28
+      '@vue/shared': 3.2.28
     dev: false
 
   /w3c-hr-time/1.0.2:

--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -106,6 +106,7 @@ declare global {
   const useCounter: typeof import('@vueuse/core')['useCounter']
   const useCssModule: typeof import('vue')['useCssModule']
   const useCssVar: typeof import('@vueuse/core')['useCssVar']
+  const useCssVars: typeof import('vue')['useCssVars']
   const useCycleList: typeof import('@vueuse/core')['useCycleList']
   const useDark: typeof import('@vueuse/core')['useDark']
   const useDebounce: typeof import('@vueuse/core')['useDebounce']

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -4,6 +4,14 @@
 
 declare module 'vue' {
   export interface GlobalComponents {
+    CarbonCampsite: typeof import('~icons/carbon/campsite')['default']
+    CarbonDicomOverlay: typeof import('~icons/carbon/dicom-overlay')['default']
+    CarbonLanguage: typeof import('~icons/carbon/language')['default']
+    CarbonLogoGithub: typeof import('~icons/carbon/logo-github')['default']
+    CarbonMoon: typeof import('~icons/carbon/moon')['default']
+    CarbonPedestrian: typeof import('~icons/carbon/pedestrian')['default']
+    CarbonSun: typeof import('~icons/carbon/sun')['default']
+    CarbonWarning: typeof import('~icons/carbon/warning')['default']
     Counter: typeof import('./components/Counter.vue')['default']
     Footer: typeof import('./components/Footer.vue')['default']
     README: typeof import('./components/README.md')['default']


### PR DESCRIPTION
Maybe we do not need add them in `devDependencies`, because they are dependencies of vue.

> Note: as of 3.2.13+, this package is included as a dependency of the main vue package and can be accessed as vue/compiler-sfc. This means you no longer need to explicitly install this package and ensure its version match that of vue's. Just use the main vue/compiler-sfc deep import instead.
> https://github.com/vuejs/core/tree/main/packages/compiler-sfc