### PR TITLE
fix(deps): update @vueuse/head to v0.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@vueuse/core": "^7.5.3",
-    "@vueuse/head": "^0.7.4",
+    "@vueuse/head": "^0.7.5",
     "nprogress": "^0.2.0",
     "pinia": "^2.0.9",
     "prism-theme-vars": "^0.2.2",


### PR DESCRIPTION
Previous versions have a severe bug that removed both static and dynamic tags seemingly at random. See https://github.com/vueuse/head/commit/3f82a4ecbeed55261a99668c19ec1573a3db742f.