### PR TITLE
fix: share dark mode state across Vue instances

### DIFF
--- a/src/composables/dark.ts
+++ b/src/composables/dark.ts
@@ -1,3 +1,3 @@
 // these APIs are auto-imported from @vueuse/core
-export const isDark = useDark()
+export const isDark = createGlobalState(useDark)()
 export const toggleDark = useToggle(isDark)


### PR DESCRIPTION
This prevents infinite isDark toggling when more than 1 Vue instance is open (i.e. across 2+ browser tabs/windows).