### PR TITLE
chore: add React fork of vitesse-lite to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ As this template is strongly opinionated, the following provides a curated list 
 - [vitesse-enterprise](https://github.com/FranciscoKloganB/vitesse-enterprise) by [@FranciscoKloganB](https://github.com/FranciscoKloganB) - Consistent coding styles regardless of team-size.
 - [vitecamp](https://github.com/nekobc1998923/vitecamp) by [@nekobc1998923](https://github.com/nekobc1998923) - Like Vitesse but without SSG/SSR/File based routing, includes Element Plus
 - [vitesse-lite-react](https://github.com/lxy-yz/vitesse-lite-react) by [@lxy-yz](https://github.com/lxy-yz) - vitesse-lite React fork
+
 ## Try it now!
 
 > Vitesse requires Node >=14

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ As this template is strongly opinionated, the following provides a curated list 
 - [vitesse-stackter-clean-architect](https://github.com/shamscorner/vitesse-stackter-clean-architect) by [@shamscorner](https://github.com/shamscorner) - A modular clean architecture pattern in vitesse template
 - [vitesse-enterprise](https://github.com/FranciscoKloganB/vitesse-enterprise) by [@FranciscoKloganB](https://github.com/FranciscoKloganB) - Consistent coding styles regardless of team-size.
 - [vitecamp](https://github.com/nekobc1998923/vitecamp) by [@nekobc1998923](https://github.com/nekobc1998923) - Like Vitesse but without SSG/SSR/File based routing, includes Element Plus
-
+- [vitesse-lite-react](https://github.com/lxy-yz/vitesse-lite-react) by [@lxy-yz](https://github.com/lxy-yz) - vitesse-lite React fork
 ## Try it now!
 
 > Vitesse requires Node >=14


### PR DESCRIPTION
Forked vitesse-lite but for React https://github.com/lxy-yz/vitesse-lite-react [live demo](https://vitesse-lite-react.netlify.app/)