### PR TITLE
refactor: use static bundle importing for i18n

### DIFF
--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -1,18 +1,13 @@
 import { createI18n } from 'vue-i18n'
-import type { UserModule } from '~/types'
-
 // Import i18n resources
-// https://vitejs.dev/guide/features.html#glob-import
-//
 // Don't need this? Try vitesse-lite: https://github.com/antfu/vitesse-lite
-const messages = Object.fromEntries(
-  Object.entries(
-    import.meta.globEager('../../locales/*.y(a)?ml'))
-    .map(([key, value]) => {
-      const yaml = key.endsWith('.yaml')
-      return [key.slice(14, yaml ? -5 : -4), value.default]
-    }),
-)
+/*
+ * Static bundle importing https://github.com/intlify/bundle-tools/tree/main/packages/vite-plugin-vue-i18n#static-bundle-importing
+ * All i18n resources specified in the plugin `include` option can be loaded
+ * at once using the import syntax
+ */
+import messages from '@intlify/vite-plugin-vue-i18n/messages'
+import type { UserModule } from '~/types'
 
 export const install: UserModule = ({ app }) => {
   const i18n = createI18n({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
       "vite/client",
       "vue/ref-macros",
       "vite-plugin-pages/client",
-      "vite-plugin-vue-layouts/client"
+      "vite-plugin-vue-layouts/client",
+      "@intlify/vite-plugin-vue-i18n/client"
     ],
     "paths": {
       "~/*": ["src/*"]


### PR DESCRIPTION
I find vue-i18n supports static bundle importing.

We can use `import messages from '@intlify/vite-plugin-vue-i18n/messages'`, and it works well.
Why not use it instead of `globEager`?