### PR TITLE
Adds `code-spell-checker` to recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
     "csstools.postcss",
     "dbaeumer.vscode-eslint",
     "johnsoncodehk.volar",
-    "lokalise.i18n-ally"
+    "lokalise.i18n-ally",
+    "streetsidesoftware.code-spell-checker"
   ]
 }


### PR DESCRIPTION
This is likely a good idea considering we use `cSpell.words` in the `settings.json`

Thanks for this great started kit!