### PR TITLE
fix: the heading 2 is rendered correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Mocking up web app with <b>Vitesse</b><sup><em>(speed)</em></sup><br>
 
 <br>
 
+
 ## Features
 
 - ⚡️ [Vue 3](https://github.com/vuejs/vue-next), [Vite 2](https://github.com/vitejs/vite), [pnpm](https://pnpm.js.org/), [ESBuild](https://github.com/evanw/esbuild) - born with fastness
@@ -60,6 +61,7 @@ Mocking up web app with <b>Vitesse</b><sup><em>(speed)</em></sup><br>
 - ☁️ Deploy on Netlify, zero-config
 
 <br>
+
 
 ## Pre-packed
 


### PR DESCRIPTION
add two line breaks to make markdown rendered correctly.

before:

![image](https://user-images.githubusercontent.com/15688641/166706119-653843b4-f851-4451-850d-1de34a7dcaca.png)
