### PR TITLE
Use vitest's defineConfig instead of vite's

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import Vue from '@vitejs/plugin-vue'
 import Pages from 'vite-plugin-pages'
 import generateSitemap from 'vite-ssg-sitemap'


### PR DESCRIPTION
The `defineConfig` method exported by Vite doesn't recognise `test` as a property but Vitest exports an extended `defineConfig` which does recognise `test`.