### PR TITLE
feat: add `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,3 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.md]
-trim_trailing_whitespace = false


### PR DESCRIPTION
Hi Antfu, I added an `.editorconfig` file to be able to override the editor's default settings.
For example, if the default indent size of the editor is 4 spaces, when I press tab, the editor will indent with 4 spaces, and then when I save, it will be formatted to 2 spaces again by eslint, which is not a friendly experience.

---

我添加了一个 `.editorconfig` 文件，以便能覆盖编辑器的默认设置。
比如缩进设置，如果编辑器默认缩进大小是 4 空格，当我按 tab 时，编辑器会以 4 空格进行缩进，然后保存时，通过 eslint 再格式化成 2 空格，体验不够友好。