### PR TITLE
docs: update docker build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Go to [Netlify](https://app.netlify.com/start) and select your clone, `OK` along
 First, build the vitesse image by opening the terminal in the project's root directory.
 
 ```bash
-docker build . -t vitesse:latest
+DOCKER_BUILDKIT=1 docker build . -t vitesse:latest
 ```
 
 Run the image and specify port mapping with the `-p` flag.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Go to [Netlify](https://app.netlify.com/start) and select your clone, `OK` along
 First, build the vitesse image by opening the terminal in the project's root directory.
 
 ```bash
-DOCKER_BUILDKIT=1 docker build . -t vitesse:latest
+docker buildx build . -t vitesse:latest
 ```
 
 Run the image and specify port mapping with the `-p` flag.


### PR DESCRIPTION
the --mount option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled