### PR TITLE
feat: add light mode button title

### DIFF
--- a/locales/ar.yml
+++ b/locales/ar.yml
@@ -5,10 +5,11 @@ button:
   home: الرئيسية
   toggle_dark: التغيير إلى الوضع المظلم
   toggle_langs: تغيير اللغة
+  toggle_light: تبديل وضع الإضاءة
 intro:
+  aka: معروف أيضا تحت مسمى
   desc: vite مثال لتطبيق
   dynamic-route: عرض لتوجيهات ديناميكية
   hi: مرحبا {name}
-  aka: معروف أيضا تحت مسمى
   whats-your-name: ما إسمك؟
 not-found: صفحة غير موجودة

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -5,10 +5,11 @@ button:
   home: Startseite
   toggle_dark: Dunkelmodus umschalten
   toggle_langs: Sprachen ändern
+  toggle_light: Lichtmodus umschalten
 intro:
+  aka: Auch bekannt als
   desc: Vite Startvorlage mit Vorlieben
   dynamic-route: Demo einer dynamischen Route
   hi: Hi, {name}!
-  aka: Auch bekannt als
   whats-your-name: Wie heißt du?
 not-found: Nicht gefunden

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,10 +5,11 @@ button:
   home: Home
   toggle_dark: Toggle dark mode
   toggle_langs: Change languages
+  toggle_light: Toggle light mode
 intro:
+  aka: Also known as
   desc: Opinionated Vite Starter Template
   dynamic-route: Demo of dynamic route
   hi: Hi, {name}!
-  aka: Also known as
   whats-your-name: What's your name?
 not-found: Not found

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -5,10 +5,11 @@ button:
   home: Inicio
   toggle_dark: Alternar modo oscuro
   toggle_langs: Cambiar idiomas
+  toggle_light: Alternar modo de luz
 intro:
+  aka: También conocido como
   desc: Plantilla de Inicio de Vite Dogmática
   dynamic-route: Demo de ruta dinámica
   hi: ¡Hola, {name}!
-  aka: También conocido como
   whats-your-name: ¿Cómo te llamas?
 not-found: No se ha encontrado

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -5,10 +5,11 @@ button:
   home: Accueil
   toggle_dark: Basculer en mode sombre
   toggle_langs: Changer de langue
+  toggle_light: Basculer le mode lumière
 intro:
+  aka: Aussi connu sous le nom de
   desc: Exemple d'application Vite
   dynamic-route: Démo de route dynamique
   hi: Salut, {name}!
-  aka: Aussi connu sous le nom de
   whats-your-name: Comment t'appelles-tu ?
 not-found: Page non trouvée

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -5,10 +5,11 @@ button:
   home: Beranda
   toggle_dark: Ubah ke mode gelap
   toggle_langs: Ubah bahasa
+  toggle_light: Beralih mode cahaya
 intro:
+  aka: Juga diketahui sebagai
   desc: Template awal vite
   dynamic-route: Contoh rute dinamik
   hi: Halo, {name}!
-  aka: Juga diketahui sebagai
   whats-your-name: Siapa nama anda?
 not-found: Tidak ditemukan

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -5,7 +5,9 @@ button:
   home: Home
   toggle_dark: Attiva/disattiva modalità scura
   toggle_langs: Cambia lingua
+  toggle_light: Attiva/disattiva la modalità luce
 intro:
+  aka: Conosciuto anche come
   desc: Modello per una Applicazione Vite
   dynamic-route: Demo di rotta dinamica
   hi: Ciao, {name}!

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -5,7 +5,9 @@ button:
   home: ホーム
   toggle_dark: ダークモード切り替え
   toggle_langs: 言語切り替え
+  toggle_light: ライトモードを切り替えます
 intro:
+  aka: としても知られている
   desc: 固執された Vite スターターテンプレート
   dynamic-route: 動的ルートのデモ
   hi: こんにちは、{name}!

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -5,7 +5,9 @@ button:
   home: 홈
   toggle_dark: 다크모드 토글
   toggle_langs: 언어 변경
+  toggle_light: 조명 모드 전환
 intro:
+  aka: 또한 ~으로 알려진
   desc: Vite 애플리케이션 템플릿
   dynamic-route: 다이나믹 라우트 데모
   hi: 안녕, {name}!

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -5,10 +5,11 @@ button:
   home: Strona główna
   toggle_dark: Ustaw tryb nocny
   toggle_langs: Zmień język
+  toggle_light: Przełącz tryb światła
 intro:
+  aka: Znany też jako
   desc: Opiniowany szablon startowy Vite
   dynamic-route: Demonstracja dynamicznego route
   hi: Cześć, {name}!
-  aka: Znany też jako
   whats-your-name: Jak masz na imię?
 not-found: Nie znaleziono

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -5,10 +5,11 @@ button:
   home: Início
   toggle_dark: Alternar modo escuro
   toggle_langs: Mudar de idioma
+  toggle_light: Alternar o modo de luz
 intro:
+  aka: Também conhecido como
   desc: Modelo Opinativo de Partida de Vite
   dynamic-route: Demonstração de rota dinâmica
   hi: Olá, {name}!
-  aka: Também conhecido como
   whats-your-name: Qual é o seu nome?
 not-found: Não encontrado

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -5,7 +5,9 @@ button:
   home: Главная
   toggle_dark: Включить темный режим
   toggle_langs: Сменить язык
+  toggle_light: Переключить световой режим
 intro:
+  aka: Также известен как
   desc: Самостоятельный начальный шаблон Vite
   dynamic-route: Демо динамического маршрута
   hi: Привет, {name}!

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -5,10 +5,11 @@ button:
   home: Anasayfa
   toggle_dark: Karanlık modu değiştir
   toggle_langs: Dilleri değiştir
+  toggle_light: Işık modunu değiştir
 intro:
+  aka: Ayrıca şöyle bilinir
   desc: Görüşlü Vite Başlangıç Şablonu
   dynamic-route: Dinamik rota demosu
   hi: Merhaba, {name}!
-  aka: Ayrıca şöyle bilinir
   whats-your-name: Adınız nedir?
 not-found: Bulunamadı

--- a/locales/vi.yml
+++ b/locales/vi.yml
@@ -5,7 +5,9 @@ button:
   home: Khởi đầu
   toggle_dark: Chuyển đổi chế độ tối
   toggle_langs: Thay đổi ngôn ngữ
+  toggle_light: Chuyển đổi chế độ ánh sáng
 intro:
+  aka: Còn được biết là
   desc: Ý kiến cá nhân Vite Template để bắt đầu
   dynamic-route: Bản giới thiệu về dynamic route
   hi: Hi, {name}!

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -5,10 +5,11 @@ button:
   home: 首页
   toggle_dark: 切换深色模式
   toggle_langs: 切换语言
+  toggle_light: 切换灯光模式
 intro:
+  aka: 也叫
   desc: 固执己见的 Vite 项目模板
   dynamic-route: 动态路由演示
   hi: 你好，{name}
-  aka: 也叫
   whats-your-name: 输入你的名字
 not-found: 未找到页面

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -14,7 +14,7 @@ const toggleLocales = () => {
       <div i-carbon-campsite />
     </RouterLink>
 
-    <button class="icon-btn mx-2 !outline-none" :title="t('button.toggle_dark')" @click="toggleDark()">
+    <button class="icon-btn mx-2 !outline-none" :title="isDark ? t('button.toggle_light') : t('button.toggle_dark')" @click="toggleDark()">
       <div i="carbon-sun dark:carbon-moon" />
     </button>
 


### PR DESCRIPTION
The light/mode button always appears to switch to dark mode. However, in dark mode, you should be prompted to switch to light mode.

I'm only familiar with Chinese and English, so other languages are automatically translated via [i18n Ally](https://marketplace.visualstudio.com/items?itemName=lokalise.i18n-ally).
