### PR TITLE
Add  Element Plus community project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ As this template is strongly opinionated, the following provides a curated list 
 - [vitesse-lite-react](https://github.com/lxy-yz/vitesse-lite-react) by [@lxy-yz](https://github.com/lxy-yz) - vitesse-lite React fork
 - [vide](https://github.com/Nico-Mayer/vide) by [@nico-mayer](https://github.com/Nico-Mayer) - Vite superlight Beginner Starter Template
 - [vitesse-h5](https://github.com/YunYouJun/vitesse-h5) by [@YunYouJun](https://github.com/YunYouJun) - Vitesse for Mobile
+- [vitesse-element-plus](https://github.com/daotl/vitesse/tree/element-plus) by [@NexZhu](https://github.com/YunYouJun) - Vitesse with [Element Plus](https://element-plus.org/), auto-importing enabled
 
 ## Try it now!
 


### PR DESCRIPTION
Description:
https://github.com/daotl/vitesse/tree/element-plus

Repo with [Element Plus](https://element-plus.org/), auto-importing enabled