### PR TITLE
docs: correct link to Component Preview repository on "Features"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Mocking up web app with <b>Vitesse</b><sup><em>(speed)</em></sup><br>
 
 - 🌍 [I18n ready](./locales)
 
-- 🔎 [Component Preview](https://github.com/antfu/vite-plugin-vue-component-preview)
+- 🔎 [Component Preview](https://github.com/johnsoncodehk/vite-plugin-vue-component-preview)
 
 - 🗒 [Markdown Support](https://github.com/antfu/vite-plugin-vue-markdown)
 


### PR DESCRIPTION
In "Features", the component preview link was leading to a dead link. 
I changed the link to be the same as the one in the "Plugins" section.