### PR TITLE
feat: use cypress-vite for running e2e tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'cypress'
+import vitePreprocessor from 'cypress-vite'
 
 export default defineConfig({
   e2e: {
@@ -6,5 +7,8 @@ export default defineConfig({
     chromeWebSecurity: false,
     specPattern: 'cypress/e2e/**/*.spec.*',
     supportFile: false,
+    setupNodeEvents(on) {
+      on('file:preprocessor', vitePreprocessor())
+    },
   },
 })

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "critters": "^0.0.16",
     "cross-env": "^7.0.3",
     "cypress": "^12.0.2",
+    "cypress-vite": "^1.3.0",
     "eslint": "^8.29.0",
     "eslint-plugin-cypress": "^2.12.1",
     "https-localhost": "^4.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ specifiers:
   critters: ^0.0.16
   cross-env: ^7.0.3
   cypress: ^12.0.2
+  cypress-vite: ^1.3.0
   eslint: ^8.29.0
   eslint-plugin-cypress: ^2.12.1
   https-localhost: ^4.7.1
@@ -70,6 +71,7 @@ devDependencies:
   critters: 0.0.16
   cross-env: 7.0.3
   cypress: 12.0.2
+  cypress-vite: 1.3.0_vite@4.0.0
   eslint: 8.29.0
   eslint-plugin-cypress: 2.12.1_eslint@8.29.0
   https-localhost: 4.7.1
@@ -1790,8 +1792,8 @@ packages:
       vue-i18n:
         optional: true
     dependencies:
-      '@intlify/message-compiler': 9.3.0-beta.10
-      '@intlify/shared': 9.3.0-beta.10
+      '@intlify/message-compiler': 9.3.0-beta.15
+      '@intlify/shared': 9.3.0-beta.15
       jsonc-eslint-parser: 1.4.1
       source-map: 0.6.1
       vue-i18n: 9.2.2_vue@3.2.45
@@ -1820,11 +1822,11 @@ packages:
       '@intlify/shared': 9.2.2
       source-map: 0.6.1
 
-  /@intlify/message-compiler/9.3.0-beta.10:
-    resolution: {integrity: sha512-RoOC6yceOykLRhN0NlbkNOBUx1el6iphx3W8NfOx3jHVNtfT1FYokx14/5sU3F1F0uxeG4sp6q+ppKvaF8o+ww==}
+  /@intlify/message-compiler/9.3.0-beta.15:
+    resolution: {integrity: sha512-kxx+pXsyoWhyFLEaJgnMk4AFiW3fvaCqpiql1alOHtkvQwzDKlrcKJ784GO4v/8SLt6JUHWfPpQH65GoYahdLA==}
     engines: {node: '>= 14'}
     dependencies:
-      '@intlify/shared': 9.3.0-beta.10
+      '@intlify/shared': 9.3.0-beta.15
       source-map: 0.6.1
     dev: true
 
@@ -1832,8 +1834,8 @@ packages:
     resolution: {integrity: sha512-wRwTpsslgZS5HNyM7uDQYZtxnbI12aGiBZURX3BTR9RFIKKRWpllTsgzHWvj3HKm3Y2Sh5LPC1r0PDCKEhVn9Q==}
     engines: {node: '>= 14'}
 
-  /@intlify/shared/9.3.0-beta.10:
-    resolution: {integrity: sha512-h93uAanbAt/XgjDHclrVB7xix6r7Uz11wx0iGNOCdHP7aA2LCJjUT3uNbekJjjbo+Fl5jzTSJZdm2SexzoqhRA==}
+  /@intlify/shared/9.3.0-beta.15:
+    resolution: {integrity: sha512-thDJ+TGK8GGmOrgh/Vul24pPvRtRGvCyuGXcw/uh2t3lyJsCPfhzY5ZihJFkGvKEl4/J4M0F/SAeWKoZNm7hlw==}
     engines: {node: '>= 14'}
     dev: true
 
@@ -1853,7 +1855,7 @@ packages:
         optional: true
     dependencies:
       '@intlify/bundle-utils': 3.4.0_vue-i18n@9.2.2
-      '@intlify/shared': 9.3.0-beta.10
+      '@intlify/shared': 9.3.0-beta.15
       '@rollup/pluginutils': 4.2.1
       '@vue/compiler-sfc': 3.2.45
       debug: 4.3.4
@@ -3911,6 +3913,17 @@ packages:
 
   /csstype/2.6.20:
     resolution: {integrity: sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==}
+
+  /cypress-vite/1.3.0_vite@4.0.0:
+    resolution: {integrity: sha512-azxkEuNWILSOIZOOy3ruEZomfwxbk0lTyc6gux4bD3rodGK7wwEQsylvBhcOAsI5jixwdkjsB4IHk/dLwJarxg==}
+    peerDependencies:
+      vite: ^2.9.0 || ^3.0.0 || ^4.0.0
+    dependencies:
+      debug: 4.3.4
+      vite: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /cypress/12.0.2:
     resolution: {integrity: sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==}


### PR DESCRIPTION
## Description

This PR installs [cypress-vite](https://github.com/mammadataei/cypress-vite) for running end-to-end test. I think since the whole development environment is based on Vite; it also makes sense to use a Vite preprocessor for running Cypress end-to-end tests.
