### PR TITLE
feat: add default alias ` @`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
       "unplugin-vue-macros/macros-global"
     ],
     "paths": {
-      "~/*": ["src/*"]
+      "~/*": ["src/*"],
+      "@/*": ["src/*"]
     }
   },
   "vueCompilerOptions": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '~/': `${path.resolve(__dirname, 'src')}/`,
+      '@/': `${path.resolve(__dirname, 'src')}/`,
     },
   },
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
1. If static pictures are introduced under src, using `~` will cause errors
2.  `@` can solve this problem, and `@` is commonly used in vue projects, and [create-vue template](https://github.com/vuejs/create-vue/blob/main/template/base/vite.config.js) is used by default `@`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
https://github.com/antfu/vitesse/issues/429

### Additional context
![image](https://user-images.githubusercontent.com/45450994/223672330-ae1b19ce-bd34-4a91-98e7-81f4615cc41d.png)
![image](https://user-images.githubusercontent.com/45450994/223672434-43451f7a-14a5-4993-b9e6-8e7d7a7f81b0.png)


<!-- e.g. is there anything you'd like reviewers to focus on? -->
