### PR TITLE
fix: title tag definition in useHead

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,12 @@
 // you can use this to manipulate the document head in any components,
 // they will be rendered correctly in the html results with vite-ssg
 useHead({
-  title: 'Vitesse',
+  templateParams: {
+    site: {
+      name: 'Vitesse',
+    },
+  },
+  titleTemplate: '%site.name',
   meta: [
     { name: 'description', content: 'Opinionated Vite Starter Template' },
     {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

[unjs/head@v1.10](https://github.com/unjs/unhead/releases/tag/v1.1.0) released a new schema for title definition that causes vitesse to render an empty title tag with vite-ssg. This pull request updates the schema for title definition in useHead, which fixes the title rendering correctly with vite-ssg.

### Linked Issues
Fixes #478 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
