### PR TITLE
docs: add new community template

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ As this template is strongly opinionated, the following provides a curated list 
 - [vitesse-h5](https://github.com/YunYouJun/vitesse-h5) by [@YunYouJun](https://github.com/YunYouJun) - Vitesse for Mobile
 - [bat](https://github.com/olgam4/bat) by [@olgam4](https://github.com/olgam4) - Vitesse for SolidJS
 - [vitesse-solid](https://github.com/xbmlz/vitesse-solid) by [@xbmlz](https://github.com/xbmlz) - Vitesse for SolidJS, build with [`SolidStart`](https://start.solidjs.com/), includes [UnoCSS](https://github.com/unocss/unocss) and [HopeUI](https://hope-ui.com/).
+- [uni-vitesse](https://github.com/Ares-Chang/uni-vitesse) by [@Ares-Chang](https://github.com/Ares-Chang) - Double the UniApp development experience with Vitesse instead of Hbuilder!
 
 ## Try it now!
 


### PR DESCRIPTION
I like Vitesse templates so much that I wanted to bring it to the platforms I use regularly.

This template combines Vitese-Lite and UniApp to develop a code that packages multi-end products.
It is also separate from the official HbuilderX and free to choose its own editor.
Hope you like this template.