### PR TITLE
ci: use `vite preview` to start prod build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,4 +93,4 @@ jobs:
         with:
           install-command: echo
           build: pnpm run build
-          start: npx vite --port 3333
+          start: npx vite preview --port 3333


### PR DESCRIPTION
### Description

The e2e tests failed due to Vite optimizing the dependencies in the dev mode. When Vite optimizes the dependencies, the page will reload. 

Set the start command to`npx vite preview --port 3333` to start the production build and prevent Vite optimizes the dependencies during testing.

Here are the simulation steps of test `markdown`:

click on the `about` link
check if URL is equal to `/about`
[vite] ✨ optimized dependencies changed. reloading
(page load)--page loaded--    -> localhost:3333/
check timeout -> test fail

#### Reproduce locally

1. open cypress
2. run a spec, then configure the network option to `Slow 3G` or `Fast 3G` in the dev tool
4. run `vite --port 3333 --force`
5. restart the test

### Linked Issues

none

### Additional context

none
