### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "vite-plugin-inspect": "^0.8.1",
     "vite-plugin-pwa": "^0.17.4",
     "vite-plugin-vue-devtools": "^1.0.0-rc.8",
-    "vite-plugin-vue-layouts": "^0.10.0",
+    "vite-plugin-vue-layouts": "^0.11.0",
     "vite-plugin-webfont-dl": "^3.9.1",
     "vite-ssg": "^0.23.6",
     "vite-ssg-sitemap": "^0.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ devDependencies:
     specifier: ^1.0.0-rc.8
     version: 1.0.0-rc.8(pug@3.0.2)(rollup@4.9.1)(vite@5.0.10)
   vite-plugin-vue-layouts:
-    specifier: ^0.10.0
-    version: 0.10.0(vite@5.0.10)(vue-router@4.2.5)(vue@3.3.13)
+    specifier: ^0.11.0
+    version: 0.11.0(vite@5.0.10)(vue-router@4.2.5)(vue@3.3.13)
   vite-plugin-webfont-dl:
     specifier: ^3.9.1
     version: 3.9.1(vite@5.0.10)
@@ -10251,8 +10251,8 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-vue-layouts@0.10.0(vite@5.0.10)(vue-router@4.2.5)(vue@3.3.13):
-    resolution: {integrity: sha512-95hG4rm3EZq1w56b+rlAC+9AxIeytaOFeBS2KDIa2ZJHyDxiWaqf/v93uLCuqkP7ye6W78B/0b7Xo4/y7mocgQ==}
+  /vite-plugin-vue-layouts@0.11.0(vite@5.0.10)(vue-router@4.2.5)(vue@3.3.13):
+    resolution: {integrity: sha512-uh6NW7lt+aOXujK4eHfiNbeo55K9OTuB7fnv+5RVc4OBn/cZull6ThXdYH03JzKanUfgt6QZ37NbbtJ0og59qw==}
     peerDependencies:
       vite: ^4.0.0 || ^5.0.0
       vue: ^3.2.4


### PR DESCRIPTION
### Description

When using the embedded route, cannot be correctly navigated to the right layout.  
Due to using an outdated version of the vite-plugin-vue-layouts.

### Linked Issues

[unplugin-vue-router discussions 268](https://github.com/posva/unplugin-vue-router/discussions/268)

