### PR TITLE
docs: add Deploy on Hostinger button

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,7 @@ docker run --rm -it -p 8080:80 vitesse:latest
 I have created several Vite apps recently. Setting the configs up is kinda the bottleneck for me to make the ideas simply come true within a very short time.
 
 So I made this starter template for myself to create apps more easily, along with some good practices that I have learned from making those apps. It's strongly opinionated, but feel free to tweak it or even maintain your own forks. [(see community maintained variation forks)](#variations)
+
+## Deployment
+
+[![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/web-apps-hosting)


### PR DESCRIPTION
This PR adds an optional **Deploy on Hostinger** badge to the README (docs-only change).

- Only README is changed
- No code, runtime, or build behavior changes
- The destination URL can be maintainer-controlled (standard Hostinger page or your own partner/affiliate link)

If this is not aligned with project policy, I can close the PR.